### PR TITLE
Ortho Camera

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ name = "draw2d"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "approx",
  "aquamarine",
  "ash",
  "flexi_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ features = [ "vulkan" ]
 
 [dev-dependencies]
 flexi_logger = "0.17.1"
+approx = "0.4.0"
 
 
 [dev-dependencies.textwrap]

--- a/examples/layered_quads/application.rs
+++ b/examples/layered_quads/application.rs
@@ -36,6 +36,8 @@ impl Application {
     }
 
     fn init(&mut self) -> Result<()> {
+        self.update_projection();
+
         let texture_handle = self.graphics.add_texture("assets/example.png")?;
 
         // background
@@ -92,14 +94,30 @@ impl Application {
                 self.window_surface.window.set_should_close(true);
             }
 
-            glfw::WindowEvent::FramebufferSize(_, _) => {
-                self.graphics.rebuild_swapchain(&self.window_surface)?;
+            glfw::WindowEvent::Size(_, _) => {
+                self.update_projection();
             }
 
             _ => {}
         }
 
         Ok(())
+    }
+
+    fn update_projection(&mut self) {
+        let (iwidth, iheight) = self.window_surface.window.get_size();
+        let half_width = iwidth as f32 / 2.0;
+        let half_height = iheight as f32 / 2.0;
+        self.graphics.set_projection(
+            &nalgebra::Matrix4::<f32>::new_orthographic(
+                -half_width,
+                half_width,
+                half_height,
+                -half_height,
+                -1.0,
+                1.0,
+            ),
+        );
     }
 }
 
@@ -112,37 +130,37 @@ impl Quads for Layer {
         self.push_vertices(&[
             // top left
             Vertex {
-                pos: [-size, -size],
+                pos: [-size, size],
                 uv: [0.0, 0.0],
                 ..Default::default()
             },
             // top right
             Vertex {
-                pos: [size, -size],
+                pos: [size, size],
                 uv: [1.0, 0.0],
                 ..Default::default()
             },
             // bottom right
             Vertex {
-                pos: [size, size],
+                pos: [size, -size],
                 uv: [1.0, 1.0],
                 ..Default::default()
             },
             // top left
             Vertex {
-                pos: [-size, -size],
+                pos: [-size, size],
                 uv: [0.0, 0.0],
                 ..Default::default()
             },
             // bottom right
             Vertex {
-                pos: [size, size],
+                pos: [size, -size],
                 uv: [1.0, 1.0],
                 ..Default::default()
             },
             // bottom left
             Vertex {
-                pos: [-size, size],
+                pos: [-size, -size],
                 uv: [0.0, 1.0],
                 ..Default::default()
             },

--- a/examples/ortho_camera/application.rs
+++ b/examples/ortho_camera/application.rs
@@ -1,0 +1,158 @@
+//! The main application state.
+//!
+//! # Example
+//!
+//! ```
+//! let mut app = Application::new()?;
+//! app.run()?;
+//! ```
+
+use draw2d::{
+    camera::{default_camera_controls, OrthoCamera},
+    GlfwWindow, Graphics, Layer, LayerHandle, Vertex,
+};
+
+use anyhow::Result;
+
+/// The main application.
+///
+/// The Application has a window, a render context, and one or more systems
+/// which can render to a frame when presented by the render context.
+pub struct Application {
+    graphics: Graphics,
+    window_surface: GlfwWindow,
+    layer: Option<LayerHandle>,
+    camera: OrthoCamera,
+}
+
+impl Application {
+    /// Build a new instance of the application.
+    pub fn new() -> Result<Self> {
+        let mut window_surface = GlfwWindow::windowed("Draw2D", 1366, 768)?;
+        window_surface.window.set_resizable(true);
+        window_surface.window.set_key_polling(true);
+        window_surface.window.set_size_polling(true);
+        window_surface.window.set_scroll_polling(true);
+        let (iw, ih) = window_surface.window.get_size();
+        Ok(Self {
+            graphics: Graphics::new(&window_surface)?,
+            window_surface,
+            layer: None,
+            camera: OrthoCamera::with_viewport(
+                ih as f32,
+                iw as f32 / ih as f32,
+            ),
+        })
+    }
+
+    fn init(&mut self) -> Result<()> {
+        self.graphics.set_projection(&self.camera.as_matrix());
+
+        let texture_handle = self.graphics.add_texture("assets/example.png")?;
+
+        // background
+        {
+            let layer_handle = self.graphics.add_layer_to_bottom();
+            let layer = self.graphics.get_layer_mut(&layer_handle).unwrap();
+            layer.set_texture(texture_handle);
+            layer.add_square(200.0);
+        }
+
+        // foreground
+        {
+            let layer_handle = self.graphics.add_layer_to_top();
+            let layer = self.graphics.get_layer_mut(&layer_handle).unwrap();
+            layer.add_square(128.0);
+        }
+
+        // (even more) foreground
+        {
+            let layer_handle = self.graphics.add_layer_to_top();
+            self.layer = Some(layer_handle);
+            let layer = self.graphics.get_layer_mut(&layer_handle).unwrap();
+            layer.set_texture(texture_handle);
+            layer.add_square(40.0);
+        }
+
+        Ok(())
+    }
+
+    fn update(&mut self) {}
+
+    /// Run the application, blocks until the main event loop exits.
+    pub fn run(mut self) -> Result<()> {
+        self.init()?;
+        while !self.window_surface.window.should_close() {
+            for (_, event) in self.window_surface.poll_events() {
+                self.handle_event(event)?;
+            }
+            self.update();
+            self.graphics.render(&self.window_surface)?;
+        }
+        Ok(())
+    }
+
+    /// Handle window events and update the application state as needed.
+    fn handle_event(&mut self, event: glfw::WindowEvent) -> Result<()> {
+        use glfw::{Action, Key, WindowEvent};
+        match event {
+            WindowEvent::Key(Key::Escape, _, Action::Press, _) => {
+                self.window_surface.window.set_should_close(true);
+            }
+            _ => {}
+        }
+
+        if default_camera_controls(&mut self.camera, &event) {
+            self.graphics.set_projection(&self.camera.as_matrix());
+        }
+
+        Ok(())
+    }
+}
+
+trait Quads {
+    fn add_square(&mut self, size: f32);
+}
+
+impl Quads for Layer {
+    fn add_square(&mut self, size: f32) {
+        self.push_vertices(&[
+            // top left
+            Vertex {
+                pos: [-size, size],
+                uv: [0.0, 0.0],
+                ..Default::default()
+            },
+            // top right
+            Vertex {
+                pos: [size, size],
+                uv: [1.0, 0.0],
+                ..Default::default()
+            },
+            // bottom right
+            Vertex {
+                pos: [size, -size],
+                uv: [1.0, 1.0],
+                ..Default::default()
+            },
+            // top left
+            Vertex {
+                pos: [-size, size],
+                uv: [0.0, 0.0],
+                ..Default::default()
+            },
+            // bottom right
+            Vertex {
+                pos: [size, -size],
+                uv: [1.0, 1.0],
+                ..Default::default()
+            },
+            // bottom left
+            Vertex {
+                pos: [-size, -size],
+                uv: [0.0, 1.0],
+                ..Default::default()
+            },
+        ]);
+    }
+}

--- a/examples/ortho_camera/main.rs
+++ b/examples/ortho_camera/main.rs
@@ -1,0 +1,57 @@
+mod application;
+
+use anyhow::{Context, Result};
+use flexi_logger::{DeferredNow, Logger, Record};
+use std::fmt::Write as FmtWrite;
+use textwrap::{termwidth, Options};
+
+fn main() -> Result<()> {
+    Logger::with_env_or_str("info")
+        .format(multiline_format)
+        .start()?;
+
+    log::info!(
+        "adjust log level by setting the RUST_LOG env var - RUST_LOG = 'info'"
+    );
+
+    let result = application::Application::new()
+        .context("failed to construct the application!")?
+        .run()
+        .context("application exited with an error");
+
+    if let Err(ref error) = result {
+        log::error!(
+            "Application exited unsuccessfully!\n{:?}\n\nroot cause: {:?}",
+            error,
+            error.root_cause()
+        );
+    }
+    result
+}
+
+fn multiline_format(
+    w: &mut dyn std::io::Write,
+    now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    let size = termwidth().min(74);
+    let wrap_options = Options::new(size)
+        .initial_indent("┏ ")
+        .subsequent_indent("┃ ");
+
+    let mut full_line = String::new();
+    writeln!(
+        full_line,
+        "{} [{}] [{}:{}]",
+        record.level(),
+        now.now().format("%H:%M:%S%.6f"),
+        record.file().unwrap_or("<unnamed>"),
+        record.line().unwrap_or(0),
+    )
+    .expect("unable to format first log line");
+
+    write!(&mut full_line, "{}", &record.args())
+        .expect("unable to format log!");
+
+    writeln!(w, "{}", textwrap::fill(&full_line, wrap_options))
+}

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -1,0 +1,71 @@
+mod ortho_camera;
+
+use nalgebra as na;
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct OrthoCamera {
+    projection: na::Orthographic3<f32>,
+    view: na::Translation2<f32>,
+    viewport_height: f32,
+    viewport_width: f32,
+}
+
+/// A really simple input handler for a camera which _just works_ for a demo.
+///
+/// Real applications will almost certainly prefer a more refined camera
+/// controller which provides a more smooth experience.
+///
+/// Returns `true` when the camera has been changed in some way. Often this is
+/// used to trigger a matrix update for the graphics subsystem.
+pub fn default_camera_controls(
+    camera: &mut OrthoCamera,
+    event: &glfw::WindowEvent,
+) -> bool {
+    use glfw::{Action, Key, WindowEvent};
+
+    let step_h = na::Vector2::new(camera.viewport_width() * 0.1, 0.0);
+    let step_v = na::Vector2::new(0.0, camera.viewport_height() * 0.1);
+    let pos = camera.world_position();
+
+    match event {
+        WindowEvent::Key(Key::Left, _, Action::Release, _)
+        | WindowEvent::Key(Key::A, _, Action::Release, _) => {
+            camera.set_world_position(&(pos - step_h));
+            true
+        }
+
+        WindowEvent::Key(Key::Right, _, Action::Release, _)
+        | WindowEvent::Key(Key::D, _, Action::Release, _) => {
+            camera.set_world_position(&(pos + step_h));
+            true
+        }
+
+        WindowEvent::Key(Key::Up, _, Action::Release, _)
+        | WindowEvent::Key(Key::W, _, Action::Release, _) => {
+            camera.set_world_position(&(pos + step_v));
+            true
+        }
+
+        WindowEvent::Key(Key::Down, _, Action::Release, _)
+        | WindowEvent::Key(Key::S, _, Action::Release, _) => {
+            camera.set_world_position(&(pos - step_v));
+            true
+        }
+
+        WindowEvent::Size(iwidth, iheight) => {
+            camera.set_aspect_ratio(*iwidth as f32 / *iheight as f32);
+            true
+        }
+
+        WindowEvent::Scroll(_xoffset, yoffset) => {
+            if *yoffset < 0.0 {
+                camera.set_viewport_height(camera.viewport_height() * 1.1);
+            } else {
+                camera.set_viewport_height(camera.viewport_height() * 0.9);
+            }
+            true
+        }
+
+        _ => false,
+    }
+}

--- a/src/camera/ortho_camera.rs
+++ b/src/camera/ortho_camera.rs
@@ -1,0 +1,277 @@
+use nalgebra as na;
+
+use crate::geometry::Rect;
+
+use super::OrthoCamera;
+
+impl OrthoCamera {
+    /// Build a new camera with a given viewport height and aspect ratio.
+    ///
+    /// # Params
+    ///
+    /// - `viewport_height` defines the height of the view rectangle in world
+    ///   space.
+    /// - `aspect_ratio` is the ratio of the desired viewport's `width/height`.
+    pub fn with_viewport(viewport_height: f32, aspect_ratio: f32) -> Self {
+        let viewport_width = viewport_height * aspect_ratio;
+        Self {
+            projection: Self::centered_ortho(viewport_width, viewport_height),
+            view: na::Translation2::identity(),
+            viewport_height,
+            viewport_width,
+        }
+    }
+
+    /// Get the camera's full transformation matrix. This can be passed to a
+    /// shader for transformations.
+    pub fn as_matrix(&self) -> na::Matrix4<f32> {
+        let view_3d = na::Translation3::new(self.view.x, self.view.y, 0.0);
+        self.projection.as_matrix() * view_3d.to_homogeneous()
+    }
+
+    /// The camera's bounds in world-space.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use draw2d::camera::*;
+    /// # use approx::assert_relative_eq;
+    /// # use nalgebra as na;
+    /// #
+    /// let ortho = OrthoCamera::with_viewport(1.0, 2.0);
+    /// let bounds = ortho.bounds();
+    ///
+    /// assert_relative_eq!(bounds.left, -1.0);
+    /// assert_relative_eq!(bounds.right, 1.0);
+    /// assert_relative_eq!(bounds.top, 0.5);
+    /// assert_relative_eq!(bounds.bottom, -0.5);
+    /// ```
+    pub fn bounds(&self) -> Rect<f32> {
+        let viewport_top_left = na::Point2::new(
+            -self.viewport_width / 2.0,
+            self.viewport_height / 2.0,
+        );
+        let viewport_bottom_right = na::Point2::new(
+            self.viewport_width / 2.0,
+            -self.viewport_height / 2.0,
+        );
+        let inverse = self.view.inverse();
+        let world_top_left = inverse.transform_point(&viewport_top_left);
+        let world_bottom_right =
+            inverse.transform_point(&viewport_bottom_right);
+        Rect {
+            left: world_top_left.x,
+            right: world_bottom_right.x,
+            top: world_top_left.y,
+            bottom: world_bottom_right.y,
+        }
+    }
+
+    /// Set the camera's position in world-space.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use draw2d::camera::*;
+    /// # use approx::assert_relative_eq;
+    /// # use nalgebra as na;
+    /// #
+    /// let mut ortho = OrthoCamera::with_viewport(2.0, 1.0);
+    /// ortho.set_world_position(&na::Point2::new(30.0, -0.5));
+    ///
+    /// assert_relative_eq!(
+    ///   ortho.world_position(),
+    ///   na::Point2::new(30.0, -0.5)
+    /// );
+    ///
+    /// let bounds = ortho.bounds();
+    /// assert_relative_eq!(bounds.left, -1.0 + 30.0);
+    /// assert_relative_eq!(bounds.right, 1.0 + 30.0);
+    /// assert_relative_eq!(bounds.top, 1.0 - 0.5);
+    /// assert_relative_eq!(bounds.bottom, -1.0 - 0.5);
+    /// ```
+    pub fn set_world_position(&mut self, world_pos: &na::Point2<f32>) {
+        self.view.x = -world_pos.x;
+        self.view.y = -world_pos.y;
+    }
+
+    /// Get the camera's position in world space.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use draw2d::camera::*;
+    /// # use approx::assert_relative_eq;
+    /// # use nalgebra as na;
+    /// #
+    /// let pos = OrthoCamera::with_viewport(1.0, 1.0).world_position();
+    ///
+    /// assert_relative_eq!(pos, na::Point2::new(0.0, 0.0));
+    /// ```
+    pub fn world_position(&self) -> na::Point2<f32> {
+        na::Point2::new(-self.view.x, -self.view.y)
+    }
+
+    /// Resize the viewport's width such that the viewing rectangle has the
+    /// desired aspect ratio.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use draw2d::camera::*;
+    /// # use approx::assert_relative_eq;
+    /// # use nalgebra as na;
+    /// #
+    /// let mut ortho = OrthoCamera::with_viewport(1.0, 1.0);
+    /// ortho.set_aspect_ratio(2.0);
+    ///
+    /// let bounds = ortho.bounds();
+    /// assert_relative_eq!(bounds.left, -1.0);
+    /// assert_relative_eq!(bounds.right, 1.0);
+    /// assert_relative_eq!(bounds.top, 0.5);
+    /// assert_relative_eq!(bounds.bottom, -0.5);
+    /// ```
+    pub fn set_aspect_ratio(&mut self, desired_aspect_ratio: f32) {
+        self.viewport_width = self.viewport_height * desired_aspect_ratio;
+        self.projection =
+            Self::centered_ortho(self.viewport_width, self.viewport_height);
+    }
+
+    /// The camera viewport's aspect ratio.
+    pub fn aspect_ratio(&self) -> f32 {
+        self.viewport_width / self.viewport_height
+    }
+
+    /// Get the height of the viewport.
+    pub fn viewport_height(&self) -> f32 {
+        self.viewport_height
+    }
+
+    /// Get the width of the viewport.
+    pub fn viewport_width(&self) -> f32 {
+        self.viewport_width
+    }
+
+    /// Set the viewport's height to a new value.
+    ///
+    /// Automatically resizes the viewport's width to maintain the current
+    /// aspect ratio.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use draw2d::camera::*;
+    /// # use approx::assert_relative_eq;
+    /// # use nalgebra as na;
+    /// #
+    /// // a camera which is 3x as wide as it is tall
+    /// let mut ortho = OrthoCamera::with_viewport(2.0, 3.0);
+    ///
+    /// assert_relative_eq!(ortho.aspect_ratio(), 3.0);
+    /// assert_relative_eq!(ortho.viewport_height(), 2.0);
+    /// assert_relative_eq!(ortho.viewport_width(), 6.0);
+    ///
+    /// ortho.set_viewport_height(3.3);
+    ///
+    /// assert_relative_eq!(ortho.aspect_ratio(), 3.0);
+    /// assert_relative_eq!(ortho.viewport_height(), 3.3);
+    /// assert_relative_eq!(ortho.viewport_width(), 9.9);
+    /// ```
+    pub fn set_viewport_height(&mut self, desired_height: f32) {
+        let current_aspect_ratio = self.aspect_ratio();
+        self.viewport_height = desired_height;
+        self.set_aspect_ratio(current_aspect_ratio);
+    }
+
+    /// Unproject a vector from normalized device coordinates (NDC) to view
+    /// space.
+    ///
+    /// Vectors are just a direction and a magnitude, so this transformation
+    /// does not apply the camera's translation in world space.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use draw2d::camera::*;
+    /// # use approx::assert_relative_eq;
+    /// # use nalgebra as na;
+    /// #
+    /// // a camera which is 3x as wide as it is tall
+    /// let mut ortho = OrthoCamera::with_viewport(2.0, 3.0);
+    ///
+    /// // the camera's world position is ignored when unprojecting a vector
+    /// ortho.set_world_position(&na::Point2::new(100.0, -34523.0));
+    ///
+    /// // Vulkan ndc coords have Y ranging from -1 at the top of the screen,
+    /// // to 1 at the bottom of the screen.
+    /// let top_right_ndc = na::Vector2::new(1.0, -1.0);
+    ///
+    /// // The unprojected vector should point to the top right of the viewport
+    /// // rectangle, but is not influenced by the camera's world position.
+    /// let unprojected = ortho.unproject_vec(&top_right_ndc);
+    /// assert_relative_eq!(unprojected, na::Vector2::new(3.0, 1.0));
+    /// ```
+    pub fn unproject_vec(&self, ndc: &na::Vector2<f32>) -> na::Vector2<f32> {
+        self.projection
+            .inverse()
+            .transform_vector(&na::Vector3::new(ndc.x, ndc.y, 0.0))
+            .xy()
+    }
+
+    /// Unproject a point from normalized device coordinates (NDC) to world
+    /// space.
+    ///
+    /// Points are logically a specific location in space. As such, the point's
+    /// coordinates will be transformed b ythe camera's location in world
+    /// space.
+    ///
+    /// e.g. this method returns where the ndc point would *actually* be
+    /// located in world coordinates.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use draw2d::camera::*;
+    /// # use approx::assert_relative_eq;
+    /// # use nalgebra as na;
+    /// #
+    /// // a camera which is 3x as wide as it is tall
+    /// let mut ortho = OrthoCamera::with_viewport(2.0, 3.0);
+    ///
+    /// // the camera's world position is ignored when unprojecting a vector
+    /// ortho.set_world_position(&na::Point2::new(100.0, -34523.0));
+    ///
+    /// // Vulkan ndc coords have Y ranging from -1 at the top of the screen,
+    /// // to 1 at the bottom of the screen.
+    /// let bottom_left_ndc = na::Point2::new(-1.0, 1.0);
+    ///
+    /// // The unprojected point should account for both the camera's viewing
+    /// // rectangle, and the camera's world position.
+    /// let unprojected = ortho.unproject_point(&bottom_left_ndc);
+    /// assert_relative_eq!(
+    ///     unprojected,
+    ///     na::Point2::new(-3.0, -1.0) + ortho.world_position().coords
+    /// );
+    /// ```
+    pub fn unproject_point(&self, ndc: &na::Point2<f32>) -> na::Point2<f32> {
+        let unprojected = self.unproject_vec(&ndc.coords);
+        self.view
+            .inverse_transform_point(&na::Point2::from(unprojected))
+    }
+
+    /// Construct an orthographic projection centered around the origin with
+    /// the provided width and height.
+    fn centered_ortho(width: f32, height: f32) -> na::Orthographic3<f32> {
+        let half_width = width / 2.0;
+        let half_height = height / 2.0;
+        na::Orthographic3::new(
+            -half_width,
+            half_width,
+            half_height,
+            -half_height,
+            1.0,
+            -1.0,
+        )
+    }
+}

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -1,0 +1,11 @@
+mod rect;
+
+use nalgebra as na;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Rect<T: na::Scalar> {
+    pub left: T,
+    pub right: T,
+    pub bottom: T,
+    pub top: T,
+}

--- a/src/geometry/rect.rs
+++ b/src/geometry/rect.rs
@@ -1,0 +1,64 @@
+use nalgebra as na;
+
+use super::Rect;
+
+impl<T: na::RealField> Rect<T> {
+    /// Check if a point is contained within this rectangle.
+    ///
+    /// # Returns
+    ///
+    /// - `true` when the point is contained within the rectangle. Comparison
+    ///   is inclusive, so the edges of the rectangle are considered 'inside'.
+    pub fn contains(&self, vec: &na::Vector2<T>) -> bool {
+        if vec.x >= self.left
+            && vec.x <= self.right
+            && vec.y >= self.bottom
+            && vec.y <= self.top
+        {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::*;
+
+    use nalgebra as na;
+
+    #[test]
+    fn not_inside() {
+        let rect = Rect {
+            left: -1.0,
+            right: 1.0,
+            bottom: -1.0,
+            top: 1.0,
+        };
+        let point = na::Point2::new(-2.0, 2.0);
+        assert!(
+            rect.contains(&point.coords) == false,
+            "the rectangle {:#?} should not contain the point {}",
+            rect,
+            point
+        );
+    }
+
+    #[test]
+    fn inside() {
+        let rect = Rect {
+            left: -1.0,
+            right: 1.0,
+            bottom: -1.0,
+            top: 1.0,
+        };
+        let point = na::Point2::new(0.5, -0.5);
+        assert!(
+            rect.contains(&point.coords) == true,
+            "the rectangle {:#?} should contain the point {}",
+            rect,
+            point
+        );
+    }
+}

--- a/src/graphics/draw2d/mod.rs
+++ b/src/graphics/draw2d/mod.rs
@@ -19,17 +19,17 @@ use super::Frame;
 use crate::graphics::vulkan::{Device, Swapchain};
 
 use anyhow::Result;
-use ash::{version::DeviceV1_0, vk};
+use ash::version::DeviceV1_0;
 use std::sync::Arc;
 
 type Mat4 = nalgebra::Matrix4<f32>;
 
 /// Resources used to render triangles
 pub struct Draw2d {
-    pub layer_stack: StackedLayers,
-    pub texture_atlas: TextureAtlas,
+    pub(super) layer_stack: StackedLayers,
+    pub(super) texture_atlas: TextureAtlas,
 
-    projection: Mat4,
+    pub(super) projection: Mat4,
 
     graphics_pipeline: Arc<GraphicsPipeline>,
     swapchain: Arc<Swapchain>,
@@ -46,7 +46,7 @@ impl Draw2d {
             texture_atlas,
             layer_stack: StackedLayers::default(),
             graphics_pipeline,
-            projection: Self::ortho(swapchain.extent),
+            projection: Mat4::identity(),
             swapchain,
             device,
         })
@@ -59,7 +59,6 @@ impl Draw2d {
         self.swapchain = swapchain;
         self.graphics_pipeline =
             GraphicsPipeline::new(&self.device, &self.swapchain)?;
-        self.projection = Self::ortho(self.swapchain.extent);
         Ok(())
     }
 
@@ -85,22 +84,6 @@ impl Draw2d {
         frame.submit_graphics_commands(&[graphics_commands]);
 
         Ok(())
-    }
-
-    /// Build a orthographic projection using an extent to compute the aspect
-    /// ratio for the screen. The height is fixed and the width varies to account
-    /// for the aspect ratio.
-    fn ortho(extent: vk::Extent2D) -> Mat4 {
-        let width = extent.width as f32;
-        let height = extent.height as f32;
-        Mat4::new_orthographic(
-            -width / 2.0,
-            width / 2.0,
-            -height / 2.0,
-            height / 2.0,
-            1.0,
-            -1.0,
-        )
     }
 }
 

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -86,4 +86,9 @@ impl Graphics {
         self.draw2d.replace_swapchain(swapchain)?;
         Ok(())
     }
+
+    /// Set the projection matrix for all graphics when they are rendered.
+    pub fn set_projection(&mut self, projection: &nalgebra::Matrix4<f32>) {
+        self.draw2d.projection = *projection;
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! A bare-minimum set of tools for rendering 2-d graphics with vulkan in rust.
 
+pub mod camera;
+pub mod geometry;
+
 mod glfw_window;
 mod graphics;
 


### PR DESCRIPTION
# Background

Currently, all geometry is rendered using an orthographic projection matrix. The projection is managed by Draw2D and is updated automatically when the swapchain is rebuilt. This approach is limited because it forces any sort of camera-based view model really clumsy.

# What Has Changed

- Define the `OrthoCamera` type which manages a view transform, and a projection matrix
- add a new example to show how the ortho camera works with default controls