### PR TITLE
Device Allocator Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ dependencies = [
  "flexi_logger",
  "glfw",
  "image",
+ "indoc",
  "log",
  "memoffset",
  "nalgebra",
@@ -324,6 +325,15 @@ dependencies = [
  "png",
  "scoped_threadpool",
  "tiff",
+]
+
+[[package]]
+name = "indoc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+dependencies = [
+ "unindent",
 ]
 
 [[package]]
@@ -847,6 +857,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ nalgebra = "*"
 memoffset = "*"
 image = "0.23.14"
 aquamarine = "*"
+indoc = "1.0.3"
 
 [dependencies.glfw]
 version = "0.41.0"

--- a/src/graphics/graphics_commands.rs
+++ b/src/graphics/graphics_commands.rs
@@ -36,7 +36,7 @@ impl Graphics {
             );
 
             let buffers = [frame.vertex_buffer.raw()];
-            let offsets = [frame.vertex_buffer.allocation().offset];
+            let offsets = [0];
             self.device.logical_device.cmd_bind_vertex_buffers(
                 command_buffer,
                 0,

--- a/src/graphics/graphics_commands.rs
+++ b/src/graphics/graphics_commands.rs
@@ -36,7 +36,7 @@ impl Graphics {
             );
 
             let buffers = [frame.vertex_buffer.raw()];
-            let offsets = [0];
+            let offsets = [frame.vertex_buffer.allocation().offset];
             self.device.logical_device.cmd_bind_vertex_buffers(
                 command_buffer,
                 0,

--- a/src/graphics/vulkan/buffer/cpu_buffer.rs
+++ b/src/graphics/vulkan/buffer/cpu_buffer.rs
@@ -63,15 +63,13 @@ impl CpuBuffer {
 
         self.resize(total_size as u64)?;
 
-        let mem_ptr = self.buffer.device.logical_device.map_memory(
-            self.buffer.allocation().memory,
-            0,
+        let allocation = self.buffer.allocation();
+        let mut ptr = self.buffer.device.logical_device.map_memory(
+            allocation.memory,
+            allocation.offset,
             self.written_size,
             vk::MemoryMapFlags::empty(),
-        )? as *mut u8;
-
-        let mut ptr =
-            mem_ptr.offset(self.buffer.allocation().offset as isize) as *mut T;
+        )? as *mut T;
 
         for entry in data_arrays {
             let mapped_slice = std::slice::from_raw_parts_mut(ptr, entry.len());
@@ -109,7 +107,8 @@ impl Buffer for CpuBuffer {
 
     /// The raw device memory handle.
     ///
-    /// Can be invalidated by calls to [write_data] or [write_data_arrays]
+    /// Can be invalidated by calls to [Self::write_data] or
+    /// [Self::write_data_arrays].
     unsafe fn allocation(&self) -> &Allocation {
         self.buffer.allocation()
     }

--- a/src/graphics/vulkan/buffer/mod.rs
+++ b/src/graphics/vulkan/buffer/mod.rs
@@ -9,6 +9,8 @@ pub use self::{
 
 use ash::vk;
 
+use super::device_allocator::Allocation;
+
 pub trait Buffer {
     /// The raw vulkan handle for the buffer. Should not be copied because
     /// implementations are allowed to invalidate the raw buffer value.
@@ -18,14 +20,8 @@ pub trait Buffer {
     /// specific implementation)
     unsafe fn raw(&self) -> vk::Buffer;
 
-    /// The raw vulkan handle to the underlying buffer memory. Should not be
-    /// copied because implementations are allowed to invalidate the raw buffer
-    /// value.
-    ///
-    /// Unsafe because it is the responsibility of the caller to ensure that
-    /// the handle will live for the duration of it's usage. (by checking the
-    /// specific implementation)
-    unsafe fn memory(&self) -> vk::DeviceMemory;
+    /// The raw handle to the buffer's underlying memory allocation.
+    unsafe fn allocation(&self) -> &Allocation;
 
     /// The size of the underlying gpu memory in bytes.
     fn size_in_bytes(&self) -> u64;

--- a/src/graphics/vulkan/buffer/static_buffer.rs
+++ b/src/graphics/vulkan/buffer/static_buffer.rs
@@ -68,7 +68,7 @@ impl StaticBuffer {
             device.logical_device.bind_buffer_memory(
                 raw,
                 allocation.memory,
-                0,
+                allocation.offset,
             )?;
         }
 

--- a/src/graphics/vulkan/buffer/static_buffer.rs
+++ b/src/graphics/vulkan/buffer/static_buffer.rs
@@ -1,5 +1,5 @@
 use super::Buffer;
-use crate::graphics::vulkan::Device;
+use crate::graphics::vulkan::{device_allocator::Allocation, Device};
 
 use anyhow::Result;
 use ash::{version::DeviceV1_0, vk};
@@ -9,8 +9,7 @@ use std::sync::Arc;
 /// allocation.
 pub struct StaticBuffer {
     raw: vk::Buffer,
-    memory: vk::DeviceMemory,
-    size: u64,
+    allocation: Allocation,
 
     usage: vk::BufferUsageFlags,
     properties: vk::MemoryPropertyFlags,
@@ -28,8 +27,7 @@ impl StaticBuffer {
     ) -> Result<Self> {
         Ok(Self {
             raw: vk::Buffer::null(),
-            memory: vk::DeviceMemory::null(),
-            size: 0,
+            allocation: Allocation::null(),
             usage,
             properties,
             device,
@@ -62,18 +60,21 @@ impl StaticBuffer {
             device.logical_device.get_buffer_memory_requirements(raw)
         };
 
-        let memory = unsafe {
+        let allocation = unsafe {
             device.allocate_memory(buffer_memory_requirements, properties)?
         };
 
         unsafe {
-            device.logical_device.bind_buffer_memory(raw, memory, 0)?;
+            device.logical_device.bind_buffer_memory(
+                raw,
+                allocation.memory,
+                0,
+            )?;
         }
 
         Ok(Self {
             raw,
-            memory,
-            size: buffer_memory_requirements.size,
+            allocation,
             usage,
             properties,
             device,
@@ -89,12 +90,12 @@ impl Buffer for StaticBuffer {
 
     /// The device memory handle. Valid for the lifetime of this buffer.
     unsafe fn memory(&self) -> vk::DeviceMemory {
-        self.memory
+        self.allocation.memory
     }
 
     /// The size, in bytes, of the allocated device memory.
     fn size_in_bytes(&self) -> u64 {
-        self.size
+        self.allocation.byte_size
     }
 }
 
@@ -109,11 +110,7 @@ impl Drop for StaticBuffer {
                 self.device.logical_device.destroy_buffer(self.raw, None);
                 self.raw = vk::Buffer::null();
             }
-
-            if self.memory != vk::DeviceMemory::null() {
-                self.device.logical_device.free_memory(self.memory, None);
-                self.memory = vk::DeviceMemory::null();
-            }
+            self.device.free_memory(&self.allocation).unwrap();
         }
     }
 }

--- a/src/graphics/vulkan/buffer/static_buffer.rs
+++ b/src/graphics/vulkan/buffer/static_buffer.rs
@@ -89,8 +89,8 @@ impl Buffer for StaticBuffer {
     }
 
     /// The device memory handle. Valid for the lifetime of this buffer.
-    unsafe fn memory(&self) -> vk::DeviceMemory {
-        self.allocation.memory
+    unsafe fn allocation(&self) -> &Allocation {
+        &self.allocation
     }
 
     /// The size, in bytes, of the allocated device memory.

--- a/src/graphics/vulkan/device_allocator/allocation.rs
+++ b/src/graphics/vulkan/device_allocator/allocation.rs
@@ -10,6 +10,7 @@ impl Allocation {
             offset: 0,
             byte_size: 0,
             memory: vk::DeviceMemory::null(),
+            memory_type_index: 0,
         }
     }
 }

--- a/src/graphics/vulkan/device_allocator/allocation.rs
+++ b/src/graphics/vulkan/device_allocator/allocation.rs
@@ -13,4 +13,9 @@ impl Allocation {
             memory_type_index: 0,
         }
     }
+
+    /// Returns true when the memory pointer is null.
+    pub fn is_null(&self) -> bool {
+        self.memory == vk::DeviceMemory::null()
+    }
 }

--- a/src/graphics/vulkan/device_allocator/allocation.rs
+++ b/src/graphics/vulkan/device_allocator/allocation.rs
@@ -1,0 +1,15 @@
+use super::Allocation;
+
+use ash::vk;
+
+impl Allocation {
+    /// Create a null allocation which has a size of zero and a null memory
+    /// handle.
+    pub fn null() -> Self {
+        Self {
+            offset: 0,
+            byte_size: 0,
+            memory: vk::DeviceMemory::null(),
+        }
+    }
+}

--- a/src/graphics/vulkan/device_allocator/forced_offset.rs
+++ b/src/graphics/vulkan/device_allocator/forced_offset.rs
@@ -1,4 +1,4 @@
-use super::{Allocation, DeviceAllocator};
+use super::{Allocation, DeviceAllocator, MemUnit};
 
 use anyhow::Result;
 use ash::vk;
@@ -8,12 +8,20 @@ use ash::vk;
 /// This has little practical use, but is convenient when verifying that other
 /// parts of the code properly handle allocation offsets.
 pub struct ForcedOffsetAllocator<Alloc: DeviceAllocator> {
+    alignment: u64,
     allocator: Alloc,
 }
 
 impl<Alloc: DeviceAllocator> ForcedOffsetAllocator<Alloc> {
-    pub fn new(allocator: Alloc) -> Self {
-        Self { allocator }
+    pub fn new(allocator: Alloc, alignment: MemUnit) -> Self {
+        Self {
+            allocator,
+            alignment: alignment.to_bytes(),
+        }
+    }
+
+    fn offset(&self) -> u64 {
+        self.alignment * 100
     }
 }
 
@@ -21,40 +29,33 @@ impl<Alloc: DeviceAllocator> DeviceAllocator for ForcedOffsetAllocator<Alloc> {
     /// Use the underlying allocator implementation to allocate an oversized
     /// piece of memory, then set an offset to compensate.
     ///
-    /// The offset will always be `memory_requirements.alignment * 100`.
-    ///
     /// This has no practical use other than proving that code properly handles
     /// memory offsets.
     unsafe fn allocate(
         &mut self,
-        memory_requirements: vk::MemoryRequirements,
-        memory_property_flags: vk::MemoryPropertyFlags,
+        allocate_info: vk::MemoryAllocateInfo,
     ) -> Result<Allocation> {
-        let alignment = memory_requirements.alignment;
-        let fixed_offset = alignment * 100;
-        let mut expanded_memory_requirements = memory_requirements.clone();
-        expanded_memory_requirements.size += fixed_offset;
-
-        let mut allocation = self
-            .allocator
-            .allocate(expanded_memory_requirements, memory_property_flags)?;
-
-        allocation.offset += fixed_offset;
-        allocation.byte_size -= fixed_offset;
-
+        let expanded_allocate_info = vk::MemoryAllocateInfo {
+            memory_type_index: allocate_info.memory_type_index,
+            allocation_size: allocate_info.allocation_size + self.offset(),
+            ..Default::default()
+        };
+        let mut allocation = self.allocator.allocate(expanded_allocate_info)?;
+        allocation.offset += self.offset();
+        allocation.byte_size = allocate_info.allocation_size;
         Ok(allocation)
     }
 
     /// Undo the offset+size adjustments which were applied by [Self::allocate],
     /// then use the underlying allocator to actually free the memory.
     unsafe fn free(&mut self, allocation: &Allocation) -> Result<()> {
-        let mut adjusted = allocation.clone();
-        adjusted.byte_size += allocation.offset;
-        adjusted.offset = 0;
-        self.allocator.free(&adjusted)
-    }
-
-    fn managed_by_me(&self, allocation: &super::Allocation) -> bool {
-        self.allocator.managed_by_me(allocation)
+        if allocation.is_null() {
+            Ok(())
+        } else {
+            let mut adjusted = allocation.clone();
+            adjusted.offset -= self.offset();
+            adjusted.byte_size += self.offset();
+            self.allocator.free(&adjusted)
+        }
     }
 }

--- a/src/graphics/vulkan/device_allocator/forced_offset.rs
+++ b/src/graphics/vulkan/device_allocator/forced_offset.rs
@@ -1,0 +1,60 @@
+use super::{Allocation, DeviceAllocator};
+
+use anyhow::Result;
+use ash::vk;
+
+/// An allocator which forces all allocations to have a fixed offset.
+///
+/// This has little practical use, but is convenient when verifying that other
+/// parts of the code properly handle allocation offsets.
+pub struct ForcedOffsetAllocator<Alloc: DeviceAllocator> {
+    allocator: Alloc,
+}
+
+impl<Alloc: DeviceAllocator> ForcedOffsetAllocator<Alloc> {
+    pub fn new(allocator: Alloc) -> Self {
+        Self { allocator }
+    }
+}
+
+impl<Alloc: DeviceAllocator> DeviceAllocator for ForcedOffsetAllocator<Alloc> {
+    /// Use the underlying allocator implementation to allocate an oversized
+    /// piece of memory, then set an offset to compensate.
+    ///
+    /// The offset will always be `memory_requirements.alignment * 100`.
+    ///
+    /// This has no practical use other than proving that code properly handles
+    /// memory offsets.
+    unsafe fn allocate(
+        &mut self,
+        memory_requirements: vk::MemoryRequirements,
+        memory_property_flags: vk::MemoryPropertyFlags,
+    ) -> Result<Allocation> {
+        let alignment = memory_requirements.alignment;
+        let fixed_offset = alignment * 100;
+        let mut expanded_memory_requirements = memory_requirements.clone();
+        expanded_memory_requirements.size += fixed_offset;
+
+        let mut allocation = self
+            .allocator
+            .allocate(expanded_memory_requirements, memory_property_flags)?;
+
+        allocation.offset += fixed_offset;
+        allocation.byte_size -= fixed_offset;
+
+        Ok(allocation)
+    }
+
+    /// Undo the offset+size adjustments which were applied by [Self::allocate],
+    /// then use the underlying allocator to actually free the memory.
+    unsafe fn free(&mut self, allocation: &Allocation) -> Result<()> {
+        let mut adjusted = allocation.clone();
+        adjusted.byte_size += allocation.offset;
+        adjusted.offset = 0;
+        self.allocator.free(&adjusted)
+    }
+
+    fn managed_by_me(&self, allocation: &super::Allocation) -> bool {
+        self.allocator.managed_by_me(allocation)
+    }
+}

--- a/src/graphics/vulkan/device_allocator/mem_unit.rs
+++ b/src/graphics/vulkan/device_allocator/mem_unit.rs
@@ -1,0 +1,29 @@
+/// Units of measurement for memory.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum MemUnit {
+    /// Bytes
+    B(u64),
+
+    /// Kibibytes (Bytes*1024)
+    KiB(u64),
+
+    /// Mebibytes (Kibibytes*1024)
+    MiB(u64),
+
+    /// Gibibytes (Mebibytes*1024)
+    GiB(u64),
+}
+
+impl MemUnit {
+    const BASE: u64 = 1024;
+
+    /// Compute the raw byte-count for the given memory unit.
+    pub fn to_bytes(&self) -> u64 {
+        match self {
+            MemUnit::B(bytes) => *bytes,
+            MemUnit::KiB(kibs) => kibs * Self::BASE,
+            MemUnit::MiB(mibs) => mibs * Self::BASE.pow(2),
+            MemUnit::GiB(gibs) => gibs * Self::BASE.pow(3),
+        }
+    }
+}

--- a/src/graphics/vulkan/device_allocator/metrics.rs
+++ b/src/graphics/vulkan/device_allocator/metrics.rs
@@ -1,0 +1,166 @@
+use super::{Allocation, DeviceAllocator};
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use ash::vk;
+
+#[derive(Debug, Copy, Clone)]
+struct Metrics {
+    total_allocations: u32,
+    max_concurrent_allocations: u32,
+    current_allocations: u32,
+    mean_allocation_byte_size: u64,
+    biggest_allocation: u64,
+    smallest_allocation: u64,
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            total_allocations: 0,
+            max_concurrent_allocations: 0,
+            current_allocations: 0,
+            mean_allocation_byte_size: 0,
+            biggest_allocation: 0,
+            smallest_allocation: u64::MAX,
+        }
+    }
+}
+
+impl Metrics {
+    pub fn add_alloctation(&mut self, allocation: &Allocation) {
+        self.current_allocations += 1;
+
+        // weighted average of allocation sizes
+        self.mean_allocation_byte_size = ((self.mean_allocation_byte_size
+            * self.total_allocations as u64)
+            + allocation.byte_size)
+            / (self.total_allocations + 1) as u64;
+
+        self.total_allocations += 1;
+
+        self.max_concurrent_allocations = self
+            .max_concurrent_allocations
+            .max(self.current_allocations);
+        self.biggest_allocation =
+            self.biggest_allocation.max(allocation.byte_size);
+        self.smallest_allocation =
+            self.smallest_allocation.min(allocation.byte_size);
+    }
+
+    pub fn remove_allocation(&mut self) {
+        self.current_allocations -= 1;
+    }
+}
+
+/// A device allocator decorator which records the number of allocations and
+/// other metrics. A summary of results is printed when the allocator is
+/// destroyed.
+pub struct MetricsAllocator<Alloc: DeviceAllocator> {
+    allocator: Alloc,
+    name: String,
+    by_type: HashMap<u32, Metrics>,
+}
+
+impl<Alloc: DeviceAllocator> MetricsAllocator<Alloc> {
+    /// Decorate an existing allocator with support for metrics.
+    pub fn new(name: impl Into<String>, allocator: Alloc) -> Self {
+        Self {
+            name: name.into(),
+            allocator,
+            by_type: HashMap::new(),
+        }
+    }
+
+    fn record_allocation(
+        &mut self,
+        memory_requirements: vk::MemoryRequirements,
+        allocation: &Allocation,
+    ) {
+        if !self.by_type.contains_key(&allocation.memory_type_index) {
+            self.by_type
+                .insert(allocation.memory_type_index, Metrics::default());
+        }
+        self.by_type
+            .get_mut(&allocation.memory_type_index)
+            .unwrap()
+            .add_alloctation(allocation);
+    }
+
+    fn record_free(&mut self, allocation: &Allocation) {
+        if !self.by_type.contains_key(&allocation.memory_type_index) {
+            return;
+        }
+        self.by_type
+            .get_mut(&allocation.memory_type_index)
+            .unwrap()
+            .remove_allocation();
+    }
+
+    fn build_report(&self) -> String {
+        let mut report = indoc::formatdoc!(
+            "
+
+            # {} - Memory Report
+
+            ",
+            self.name
+        );
+
+        for (memory_type_index, metrics) in &self.by_type {
+            let entry = indoc::formatdoc!(
+                "
+                ## Metrics For Memory Type Index {}
+
+                  - max concurrent allocations | {}
+                  -          total allocations | {}
+                  -         mean size in bytes | {}b
+                  -         largest allocation | {}b
+                  -        smallest allocation | {}b
+                  -         leaked allocations | {}
+
+                ",
+                memory_type_index,
+                metrics.max_concurrent_allocations,
+                metrics.total_allocations,
+                metrics.mean_allocation_byte_size,
+                metrics.biggest_allocation,
+                metrics.smallest_allocation,
+                metrics.current_allocations
+            );
+            report += entry.as_ref();
+        }
+
+        report
+    }
+}
+
+impl<Alloc: DeviceAllocator> DeviceAllocator for MetricsAllocator<Alloc> {
+    unsafe fn allocate(
+        &mut self,
+        memory_requirements: vk::MemoryRequirements,
+        property_flags: vk::MemoryPropertyFlags,
+    ) -> Result<Allocation> {
+        let allocation = self
+            .allocator
+            .allocate(memory_requirements, property_flags)?;
+        self.record_allocation(memory_requirements, &allocation);
+        Ok(allocation)
+    }
+
+    unsafe fn free(&mut self, allocation: &Allocation) -> Result<()> {
+        self.record_free(allocation);
+        self.allocator.free(allocation)
+    }
+
+    fn managed_by_me(&self, allocation: &Allocation) -> bool {
+        self.allocator.managed_by_me(allocation)
+    }
+}
+
+impl<T: DeviceAllocator> Drop for MetricsAllocator<T> {
+    fn drop(&mut self) {
+        log::debug!("{}", self.build_report());
+    }
+}

--- a/src/graphics/vulkan/device_allocator/metrics/console_markdown_report.rs
+++ b/src/graphics/vulkan/device_allocator/metrics/console_markdown_report.rs
@@ -1,0 +1,173 @@
+use super::{Metrics, MetricsReport};
+
+use std::collections::HashMap;
+
+/// Build a human-friendly markdown report which is printed directly to the
+/// console.
+///
+/// Reports Look similar to the following:-
+///
+/// ```markdown
+/// # Device Allocator - Memory Report Totals
+///
+///   |                Metric Name | Value        |
+///   | -------------------------- | ------------ |
+///   | max concurrent allocations | 6            |
+///   |     total allocation count | 7            |
+///   |    leaked allocation count | 0            |
+///   |       mean allocation size | 25.07 KiB    |
+///   |         biggest allocation | 87 KiB       |
+///   |        smallest allocation | 256 B        |
+///
+///
+/// ## Metrics By Memory Type Index
+///
+/// ### Memory Type 7
+///
+///   |                Metric Name | Value        |
+///   | -------------------------- | ------------ |
+///   | max concurrent allocations | 2            |
+///   |     total allocation count | 2            |
+///   |    leaked allocation count | 0            |
+///   |       mean allocation size | 43.75 KiB    |
+///   |         biggest allocation | 87 KiB       |
+///   |        smallest allocation | 512 B        |
+///
+/// ### Memory Type 8
+///
+///   |                Metric Name | Value        |
+///   | -------------------------- | ------------ |
+///   | max concurrent allocations | 4            |
+///   |     total allocation count | 5            |
+///   |    leaked allocation count | 0            |
+///   |       mean allocation size | 17.599 KiB   |
+///   |         biggest allocation | 85.5 KiB     |
+///   |        smallest allocation | 256 B        |
+/// ```
+///
+pub struct ConsoleMarkdownReport {}
+
+impl ConsoleMarkdownReport {
+    const BASE: u64 = 1024;
+    const UNITS: [&'static str; 4] = ["B", "KiB", "MiB", "GiB"];
+
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    fn formatted_metrics_list(metrics: &Metrics) -> String {
+        indoc::formatdoc!(
+            "
+            {indent}|                Metric Name | {header:<12} |
+            {indent}| -------------------------- | {underline:<12} |
+            {indent}| max concurrent allocations | {:<12} |
+            {indent}|     total allocation count | {:<12} |
+            {indent}|    leaked allocation count | {:<12} |
+            {indent}|       mean allocation size | {:<12} |
+            {indent}|         biggest allocation | {:<12} |
+            {indent}|        smallest allocation | {:<12} |
+            ",
+            metrics.max_concurrent_allocations,
+            metrics.total_allocations,
+            metrics.current_allocations,
+            Self::pretty_print_bytes(metrics.mean_allocation_byte_size),
+            Self::pretty_print_bytes(metrics.biggest_allocation),
+            Self::pretty_print_bytes(metrics.smallest_allocation),
+            header = "Value",
+            underline = "------------",
+            indent = "  ",
+        )
+    }
+
+    fn pretty_print_bytes(byte_size: u64) -> String {
+        let order_of_magnitude = Self::order_of_magnitude(byte_size);
+        let divisor = Self::BASE.pow(order_of_magnitude as u32);
+
+        // This weird bit of gymnastics ensures that there are at *most* 3
+        // numbers after the decimal, but only if the precision is actually
+        // needed. (e.g. 256.000 will render as just 256 in the final report)
+        let full_print = format!("{:.3}", byte_size as f32 / divisor as f32);
+        let truncated: f32 = full_print.parse().unwrap();
+
+        format!(
+            "{size} {unit}",
+            size = truncated,
+            unit = Self::UNITS[order_of_magnitude]
+        )
+    }
+
+    /// Compute the order of magnitude in units of 1024.
+    ///
+    /// This could probably be improved with some logarithms (division in a
+    /// loop, I'm looking at you!), but the while loop works just fine.
+    fn order_of_magnitude(byte_size: u64) -> usize {
+        let mut order_of_magnitude = 0;
+        let mut remaining_precision = byte_size as f64;
+        while remaining_precision >= 1.0 {
+            remaining_precision /= 1024.0;
+            order_of_magnitude += 1;
+        }
+        if order_of_magnitude > 0 {
+            order_of_magnitude -= 1;
+        }
+        order_of_magnitude.min(Self::UNITS.len())
+    }
+}
+
+impl MetricsReport for ConsoleMarkdownReport {
+    fn render(
+        &self,
+        name: &str,
+        total: &Metrics,
+        metrics_by_type: &HashMap<u32, Metrics>,
+    ) {
+        let mut report = indoc::formatdoc!(
+            "
+
+            # {name} - Memory Report Totals
+
+            {totals}
+
+            ## Metrics By Memory Type Index
+
+            ",
+            name = name,
+            totals = Self::formatted_metrics_list(total)
+        );
+
+        for (memory_type_index, metrics) in metrics_by_type {
+            report += indoc::formatdoc!(
+                "### Memory Type {type}
+
+                {metrics}
+                ",
+                type = memory_type_index,
+                metrics = Self::formatted_metrics_list(&metrics)
+            )
+            .as_ref();
+        }
+
+        log::info!("{}", report);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    pub fn test_pretty_print_bytes() {
+        use ConsoleMarkdownReport as CMR;
+
+        assert_eq!(CMR::pretty_print_bytes(1), "1 B");
+        assert_eq!(CMR::pretty_print_bytes(1024), "1 KiB");
+        assert_eq!(CMR::pretty_print_bytes(1024 * 1024), "1 MiB");
+        assert_eq!(CMR::pretty_print_bytes(1024 * 1024 * 1024), "1 GiB");
+
+        assert_eq!(CMR::pretty_print_bytes(1000), "1000 B");
+        assert_eq!(CMR::pretty_print_bytes(1034), "1.01 KiB");
+        assert_eq!(CMR::pretty_print_bytes(2048), "2 KiB");
+        assert_eq!(CMR::pretty_print_bytes(4096), "4 KiB");
+        assert_eq!(CMR::pretty_print_bytes(34235), "33.433 KiB");
+    }
+}

--- a/src/graphics/vulkan/device_allocator/metrics/metrics.rs
+++ b/src/graphics/vulkan/device_allocator/metrics/metrics.rs
@@ -1,0 +1,91 @@
+use crate::graphics::vulkan::device_allocator::Allocation;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Metrics {
+    pub total_allocations: u32,
+    pub max_concurrent_allocations: u32,
+    pub current_allocations: u32,
+    pub mean_allocation_byte_size: u64,
+    pub biggest_allocation: u64,
+    pub smallest_allocation: u64,
+}
+
+impl Default for Metrics {
+    /// Create an empty metrics object with all counters set to zero or their
+    /// reasonable defaults.
+    fn default() -> Self {
+        Self {
+            total_allocations: 0,
+            max_concurrent_allocations: 0,
+            current_allocations: 0,
+            mean_allocation_byte_size: 0,
+            biggest_allocation: 0,
+            smallest_allocation: u64::MAX,
+        }
+    }
+}
+
+impl Metrics {
+    /// Update counters within the metrics data structure in response to a new
+    /// allocation being acquired.
+    pub fn measure_alloctaion(&mut self, allocation: &Allocation) {
+        self.current_allocations += 1;
+
+        // weighted average of allocation sizes
+        self.mean_allocation_byte_size = ((self.mean_allocation_byte_size
+            * self.total_allocations as u64)
+            + allocation.byte_size)
+            / (self.total_allocations + 1) as u64;
+
+        self.total_allocations += 1;
+
+        self.max_concurrent_allocations = self
+            .max_concurrent_allocations
+            .max(self.current_allocations);
+        self.biggest_allocation =
+            self.biggest_allocation.max(allocation.byte_size);
+        self.smallest_allocation =
+            self.smallest_allocation.min(allocation.byte_size);
+    }
+
+    /// Update counters within the metrics data structure in response to an
+    /// allocation being freed.
+    pub fn measure_free(&mut self) {
+        self.current_allocations -= 1;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_mean_allocation_size() {
+        let mut metrics = Metrics::default();
+        metrics.measure_alloctaion(&allocation_with_size(100));
+        metrics.measure_alloctaion(&allocation_with_size(50));
+        metrics.measure_alloctaion(&allocation_with_size(75));
+
+        assert_eq!(metrics.mean_allocation_byte_size, 75);
+    }
+
+    #[test]
+    fn test_allocation_counters() {
+        let mut metrics = Metrics::default();
+        metrics.measure_alloctaion(&allocation_with_size(100));
+        metrics.measure_alloctaion(&allocation_with_size(50));
+        metrics.measure_alloctaion(&allocation_with_size(75));
+        metrics.measure_free();
+
+        assert_eq!(metrics.current_allocations, 2);
+        assert_eq!(metrics.smallest_allocation, 50);
+        assert_eq!(metrics.biggest_allocation, 100);
+        assert_eq!(metrics.max_concurrent_allocations, 3);
+    }
+
+    fn allocation_with_size(size: u64) -> Allocation {
+        let mut allocation = Allocation::null();
+        allocation.byte_size = size;
+        allocation
+    }
+}

--- a/src/graphics/vulkan/device_allocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/mod.rs
@@ -101,15 +101,16 @@ pub fn build_standard_allocator(
     physical_device: ash::vk::PhysicalDevice,
 ) -> Box<impl DeviceAllocator> {
     Box::new(
-        // shared ref
         SharedRefAllocator::new(
-            // with metrics
+            // Capture metrics for the device allocator
             MetricsAllocator::new(
                 "Device Allocator",
-                ConsoleMarkdownReport::new(),
-                //passthrough
+                ConsoleMarkdownReport::new(
+                    ash_instance.clone(),
+                    physical_device,
+                ),
                 PassthroughAllocator::create(
-                    ash_instance,
+                    ash_instance.clone(),
                     logical_device,
                     physical_device,
                 ),

--- a/src/graphics/vulkan/device_allocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/mod.rs
@@ -102,8 +102,19 @@ pub fn build_standard_allocator(
             })
             .expect("ahhhhh!!!!")
     });
+    let allocation = unsafe {
+        sub.allocate(vk::MemoryAllocateInfo {
+            allocation_size: 256,
+            memory_type_index: 7,
+            ..Default::default()
+        })
+        .unwrap()
+    };
     unsafe {
-        sub.free_all(&mut system_allocator)
+        sub.free(&allocation).unwrap();
+    };
+    unsafe {
+        sub.free_block(&mut system_allocator)
             .expect("free the suballocator!");
     }
 

--- a/src/graphics/vulkan/device_allocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/mod.rs
@@ -104,11 +104,5 @@ pub fn build_standard_allocator(
         },
     );
 
-    let system_allocator = MetricsAllocator::new(
-        "Application Allocator Interface",
-        ConsoleMarkdownReport::new(ash_instance.clone(), physical_device),
-        typed_allocator,
-    );
-
-    Box::new(system_allocator)
+    Box::new(typed_allocator)
 }

--- a/src/graphics/vulkan/device_allocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/mod.rs
@@ -13,6 +13,7 @@
 
 mod allocation;
 mod forced_offset;
+mod metrics;
 mod passthrough;
 mod shared_ref;
 
@@ -23,8 +24,8 @@ use anyhow::Result;
 use ash::vk;
 
 pub use self::{
-    forced_offset::ForcedOffsetAllocator, passthrough::PassthroughAllocator,
-    shared_ref::SharedRefAllocator,
+    forced_offset::ForcedOffsetAllocator, metrics::MetricsAllocator,
+    passthrough::PassthroughAllocator, shared_ref::SharedRefAllocator,
 };
 
 /// A single allocated piece of device memory.
@@ -33,6 +34,7 @@ pub struct Allocation {
     pub memory: vk::DeviceMemory,
     pub offset: vk::DeviceSize,
     pub byte_size: vk::DeviceSize,
+    memory_type_index: u32,
 }
 
 pub trait DeviceAllocator {
@@ -77,8 +79,9 @@ pub fn build_standard_allocator(
     Box::new(
         // shared ref
         SharedRefAllocator::new(
-            // forced offset
-            ForcedOffsetAllocator::new(
+            // with metrics
+            MetricsAllocator::new(
+                "Device Allocator",
                 //passthrough
                 PassthroughAllocator::create(
                     ash_instance,

--- a/src/graphics/vulkan/device_allocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/mod.rs
@@ -6,10 +6,9 @@
 //! Allocator Implementations (brainstorm):
 //! - passthrough allocator -> directly allocates a new block of device memory
 //!   - done!
-//! - null allocator -> always returns an error
 //! - metric-gathering allocator -> decorates an allocator with metrics
+//!   - done!
 //! - pooling allocator -> something something, gpu memory pools
-//! - freelist? does this make sense for device memory?
 
 mod allocation;
 mod forced_offset;

--- a/src/graphics/vulkan/device_allocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/mod.rs
@@ -4,8 +4,9 @@
 //! Big Idea: Allocators should compose.
 //!
 //! Allocator Implementations (brainstorm):
-//! - null allocator -> always returns an error
 //! - passthrough allocator -> directly allocates a new block of device memory
+//!   - done!
+//! - null allocator -> always returns an error
 //! - metric-gathering allocator -> decorates an allocator with metrics
 //! - pooling allocator -> something something, gpu memory pools
 //! - freelist? does this make sense for device memory?

--- a/src/graphics/vulkan/device_allocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/mod.rs
@@ -1,0 +1,37 @@
+//! This module defines traits and implementations for managing device (gpu)
+//! memory.
+//!
+//! Big Idea: Allocators should compose.
+//!
+//! Allocator Implementations (brainstorm):
+//! - null allocator -> always returns an error
+//! - passthrough allocator -> directly allocates a new block of device memory
+//! - metric-gathering allocator -> decorates an allocator with metrics
+//! - pooling allocator -> something something, gpu memory pools
+//! - freelist? does this make sense for device memory?
+
+use anyhow::Result;
+use ash::vk;
+
+/// A single allocated piece of device memory.
+pub struct Allocation {
+    memory: vk::DeviceMemory,
+    offset: vk::DeviceSize,
+    byte_size: vk::DeviceSize,
+}
+
+pub trait DeviceAllocator {
+    /// Allocate a piece of device memory given the requirements and usage.
+    fn allocate(
+        &mut self,
+        memory_requirements: vk::MemoryRequirements,
+        property_flags: vk::MemoryPropertyFlags,
+    ) -> Result<Allocation>;
+
+    /// Free an allocated piece of device memory.
+    fn free(&mut self, allocation: Allocation) -> Result<()>;
+
+    /// True when this specific allocator implementation knows how to manage
+    /// allocation.
+    fn managed_by_me(&self, allocation: &Allocation) -> bool;
+}

--- a/src/graphics/vulkan/device_allocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/mod.rs
@@ -14,12 +14,17 @@
 mod allocation;
 mod forced_offset;
 mod passthrough;
+mod shared_ref;
+
+#[cfg(test)]
+mod stub_allocator;
 
 use anyhow::Result;
 use ash::vk;
 
 pub use self::{
     forced_offset::ForcedOffsetAllocator, passthrough::PassthroughAllocator,
+    shared_ref::SharedRefAllocator,
 };
 
 /// A single allocated piece of device memory.
@@ -33,8 +38,10 @@ pub struct Allocation {
 pub trait DeviceAllocator {
     /// Allocate a piece of device memory given the requirements and usage.
     ///
-    /// UNSAFE: because it is the responsibility of the caller to free the
-    /// returned memory when it is no longer in use.
+    /// # unsafe because
+    ///
+    /// - it is the responsibility of the caller to free the returned memory
+    ///   when it is no longer in use
     unsafe fn allocate(
         &mut self,
         memory_requirements: vk::MemoryRequirements,
@@ -46,10 +53,40 @@ pub trait DeviceAllocator {
     /// # unsafe because
     ///
     /// - it is the responsibility of the caller to know when the GPU is no
-    ///   longer using the allocation.
+    ///   longer using the allocation
     unsafe fn free(&mut self, allocation: &Allocation) -> Result<()>;
 
     /// True when this specific allocator implementation knows how to manage
     /// allocation.
     fn managed_by_me(&self, allocation: &Allocation) -> bool;
+}
+
+/// Build the standard allocator implementation.
+///
+/// The return is a boxed impl so that consumers are not dependent on the
+/// specific implementation (often the full type is unwieldy because it is a
+/// composition of DeviceAllocator implementations).
+///
+/// The caller is responsible for keeping the ash instance, logical device, and
+/// physical device alive for at least as long as the allocator exists.
+pub fn build_standard_allocator(
+    ash_instance: ash::Instance,
+    logical_device: ash::Device,
+    physical_device: ash::vk::PhysicalDevice,
+) -> Box<impl DeviceAllocator> {
+    Box::new(
+        // shared ref
+        SharedRefAllocator::new(
+            // forced offset
+            ForcedOffsetAllocator::new(
+                //passthrough
+                PassthroughAllocator::create(
+                    ash_instance,
+                    logical_device,
+                    physical_device,
+                ),
+            ),
+        )
+        .clone(),
+    )
 }

--- a/src/graphics/vulkan/device_allocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/mod.rs
@@ -12,14 +12,18 @@
 //! - freelist? does this make sense for device memory?
 
 mod allocation;
+mod forced_offset;
 mod passthrough;
 
 use anyhow::Result;
 use ash::vk;
 
-pub use passthrough::PassthroughAllocator;
+pub use self::{
+    forced_offset::ForcedOffsetAllocator, passthrough::PassthroughAllocator,
+};
 
 /// A single allocated piece of device memory.
+#[derive(Clone)]
 pub struct Allocation {
     pub memory: vk::DeviceMemory,
     pub offset: vk::DeviceSize,

--- a/src/graphics/vulkan/device_allocator/page_allocator.rs
+++ b/src/graphics/vulkan/device_allocator/page_allocator.rs
@@ -1,0 +1,78 @@
+use super::{Allocation, DeviceAllocator, MemUnit};
+
+use anyhow::Result;
+use ash::vk;
+
+/// Decorate an allocator such that all allocation requests are rounded up to
+/// the nearest page.
+pub struct PageAllocator<Allocator: DeviceAllocator> {
+    parent: Allocator,
+    page_size: u64,
+}
+
+impl<Allocator: DeviceAllocator> PageAllocator<Allocator> {
+    /// Decorate an allocator such that all of the underlying allocations occur
+    /// on page boundaries.
+    pub fn new(parent: Allocator, page_size: MemUnit) -> Self {
+        Self {
+            parent,
+            page_size: page_size.to_bytes(),
+        }
+    }
+
+    fn round_up_to_nearest_page(&self, size: u64) -> u64 {
+        let pages = (size as f64 / self.page_size as f64).ceil() as u64;
+        pages * self.page_size
+    }
+}
+
+impl<Allocator: DeviceAllocator> DeviceAllocator for PageAllocator<Allocator> {
+    unsafe fn allocate(
+        &mut self,
+        memory_allocate_info: vk::MemoryAllocateInfo,
+    ) -> Result<Allocation> {
+        let aligned_memory_allocate_info = vk::MemoryAllocateInfo {
+            memory_type_index: memory_allocate_info.memory_type_index,
+            allocation_size: self
+                .round_up_to_nearest_page(memory_allocate_info.allocation_size),
+            ..Default::default()
+        };
+
+        // used the aligned size when actually allocating
+        let mut allocation =
+            self.parent.allocate(aligned_memory_allocate_info)?;
+
+        // but tell the caller the size they expect
+        allocation.byte_size = memory_allocate_info.allocation_size;
+
+        Ok(allocation)
+    }
+
+    unsafe fn free(&mut self, allocation: &Allocation) -> Result<()> {
+        let mut aligned_allocation = allocation.clone();
+        aligned_allocation.byte_size =
+            self.round_up_to_nearest_page(allocation.byte_size);
+        self.parent.free(&aligned_allocation)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::graphics::vulkan::device_allocator::stub_allocator::StubAllocator;
+
+    #[test]
+    pub fn test_round_to_nearest_page() {
+        let allocator = PageAllocator::new(StubAllocator {}, MemUnit::B(256));
+
+        assert_eq!(allocator.round_up_to_nearest_page(0), 0);
+        assert_eq!(allocator.round_up_to_nearest_page(256), 256);
+        assert_eq!(allocator.round_up_to_nearest_page(20), 256);
+        assert_eq!(allocator.round_up_to_nearest_page(257), 512);
+        assert_eq!(
+            allocator
+                .round_up_to_nearest_page(MemUnit::GiB(1024).to_bytes() + 1),
+            MemUnit::GiB(1024).to_bytes() + 256
+        );
+    }
+}

--- a/src/graphics/vulkan/device_allocator/passthrough.rs
+++ b/src/graphics/vulkan/device_allocator/passthrough.rs
@@ -1,0 +1,105 @@
+use super::{Allocation, DeviceAllocator};
+
+use anyhow::Result;
+use ash::{
+    version::{DeviceV1_0, InstanceV1_0},
+    vk,
+};
+
+/// An allocator implementation which just directly allocates a new piece of
+/// device memory on each call.
+///
+/// This allocator is stateles and can be cheaply cloned when building
+/// allocators which decorate this behavior.
+#[derive(Clone)]
+pub struct PassthroughAllocator {
+    /// A non-owning copy of the ash instance. e.g. Whoever creates this struct
+    /// must make sure that the ash instance outlives this struct.
+    ash_instance: ash::Instance,
+
+    /// A non-owning copy of the vulkan logical device.
+    logical_device: ash::Device,
+
+    /// A non-owning copy of the vulkan phypsical device.
+    physical_device: ash::vk::PhysicalDevice,
+}
+
+impl PassthroughAllocator {
+    /// Create a new stateless passthrough allocator which just directly
+    /// allocates and deallocates memory using the vulkan logical device.
+    pub fn create(
+        ash_instance: ash::Instance,
+        logical_device: ash::Device,
+        physical_device: ash::vk::PhysicalDevice,
+    ) -> Self {
+        Self {
+            ash_instance,
+            logical_device,
+            physical_device,
+        }
+    }
+}
+
+impl DeviceAllocator for PassthroughAllocator {
+    unsafe fn allocate(
+        &mut self,
+        memory_requirements: vk::MemoryRequirements,
+        property_flags: vk::MemoryPropertyFlags,
+    ) -> Result<Allocation> {
+        use anyhow::Context;
+
+        let memory_properties = self
+            .ash_instance
+            .get_physical_device_memory_properties(self.physical_device);
+
+        let memory_type_index = memory_properties
+            .memory_types
+            .iter()
+            .enumerate()
+            .find(|(i, memory_type)| {
+                let type_supported =
+                    memory_requirements.memory_type_bits & (1 << i) != 0;
+                let properties_supported =
+                    memory_type.property_flags.contains(property_flags);
+                type_supported & properties_supported
+            })
+            .map(|(i, _memory_type)| i as u32)
+            .with_context(|| {
+                "unable to find a suitable memory type for this allocation!"
+            })?;
+
+        let allocate_info = vk::MemoryAllocateInfo {
+            memory_type_index,
+            allocation_size: memory_requirements.size,
+            ..Default::default()
+        };
+
+        let memory =
+            self.logical_device.allocate_memory(&allocate_info, None)?;
+
+        Ok(Allocation {
+            memory,
+            offset: 0,
+            byte_size: allocate_info.allocation_size,
+        })
+    }
+
+    /// Free the allocation's underlying memory.
+    ///
+    /// # unsafe because
+    ///
+    /// - it is the responsibility of the caller to ensure the allocation's
+    ///   device memory is no longer in use
+    /// - this *includes* other allocations which reference the same piece of
+    ///   memory! Don't double-free!
+    ///
+    unsafe fn free(&mut self, allocation: &Allocation) -> Result<()> {
+        self.logical_device.free_memory(allocation.memory, None);
+        Ok(())
+    }
+
+    /// The passthrough allocator assumes that all memory is owned by itself.
+    fn managed_by_me(&self, _allocation: &super::Allocation) -> bool {
+        true
+    }
+}

--- a/src/graphics/vulkan/device_allocator/passthrough.rs
+++ b/src/graphics/vulkan/device_allocator/passthrough.rs
@@ -81,6 +81,7 @@ impl DeviceAllocator for PassthroughAllocator {
             memory,
             offset: 0,
             byte_size: allocate_info.allocation_size,
+            memory_type_index,
         })
     }
 

--- a/src/graphics/vulkan/device_allocator/pool.rs
+++ b/src/graphics/vulkan/device_allocator/pool.rs
@@ -1,0 +1,74 @@
+use super::{Allocation, DeviceAllocator, MemUnit, Suballocator};
+
+use anyhow::Result;
+use ash::vk;
+use std::collections::HashMap;
+
+pub struct PoolAllocator<Allocator: DeviceAllocator> {
+    parent: Allocator,
+    block_size: u64,
+    blocks: HashMap<vk::DeviceMemory, Suballocator>,
+}
+
+impl<Allocator: DeviceAllocator> PoolAllocator<Allocator> {
+    /// Create a new pool allocator which suballocates memory from large
+    /// blocks.
+    pub fn new(allocator: Allocator, block_size: MemUnit) -> Self {
+        Self {
+            parent: allocator,
+            block_size: block_size.to_bytes(),
+            blocks: HashMap::new(),
+        }
+    }
+}
+
+impl<Allocator: DeviceAllocator> DeviceAllocator for PoolAllocator<Allocator> {
+    unsafe fn allocate(
+        &mut self,
+        memory_allocate_info: vk::MemoryAllocateInfo,
+    ) -> Result<Allocation> {
+        if memory_allocate_info.allocation_size > self.block_size {
+            anyhow::bail!("This pool is unable to allocate a block that large!")
+        }
+
+        for (_, suballocator) in &mut self.blocks {
+            if let Ok(allocation) = suballocator.allocate(memory_allocate_info)
+            {
+                return Ok(allocation);
+            }
+        }
+
+        let new_block_allocation =
+            self.parent.allocate(vk::MemoryAllocateInfo {
+                memory_type_index: memory_allocate_info.memory_type_index,
+                allocation_size: self.block_size,
+                ..Default::default()
+            })?;
+        let mut suballocator = Suballocator::new(new_block_allocation.clone());
+
+        let allocation = suballocator.allocate(memory_allocate_info)?;
+        self.blocks
+            .insert(new_block_allocation.memory, suballocator);
+
+        Ok(allocation)
+    }
+
+    unsafe fn free(&mut self, allocation: &Allocation) -> Result<()> {
+        if allocation.is_null() {
+            Ok(())
+        } else if self.blocks.contains_key(&allocation.memory) {
+            let suballocator = self.blocks.get_mut(&allocation.memory).unwrap();
+            suballocator.free(allocation)?;
+            if suballocator.is_empty() {
+                suballocator.free_block(&mut self.parent)?;
+                self.blocks.remove(&allocation.memory);
+            }
+            Ok(())
+        } else {
+            anyhow::bail!(format!(
+                "this pool did not allocate that memory! {:#?}\n {:#?}",
+                allocation, self.blocks
+            ))
+        }
+    }
+}

--- a/src/graphics/vulkan/device_allocator/shared_ref.rs
+++ b/src/graphics/vulkan/device_allocator/shared_ref.rs
@@ -1,4 +1,4 @@
-use super::{Allocation, DeviceAllocator, MemoryTypeAllocator};
+use super::{Allocation, DeviceAllocator};
 
 use anyhow::Result;
 use ash::vk;
@@ -33,12 +33,9 @@ impl<Alloc: DeviceAllocator> Clone for SharedRefAllocator<Alloc> {
 impl<Alloc: DeviceAllocator> DeviceAllocator for SharedRefAllocator<Alloc> {
     unsafe fn allocate(
         &mut self,
-        memory_requirements: vk::MemoryRequirements,
-        memory_property_flags: vk::MemoryPropertyFlags,
+        allocate_info: vk::MemoryAllocateInfo,
     ) -> Result<Allocation> {
-        self.allocator
-            .borrow_mut()
-            .allocate(memory_requirements, memory_property_flags)
+        self.allocator.borrow_mut().allocate(allocate_info)
     }
 
     unsafe fn free(
@@ -46,27 +43,6 @@ impl<Alloc: DeviceAllocator> DeviceAllocator for SharedRefAllocator<Alloc> {
         allocation: &super::Allocation,
     ) -> anyhow::Result<()> {
         self.allocator.borrow_mut().free(allocation)
-    }
-
-    fn managed_by_me(&self, allocation: &super::Allocation) -> bool {
-        self.allocator.borrow().managed_by_me(allocation)
-    }
-}
-
-impl<Alloc: MemoryTypeAllocator + DeviceAllocator> MemoryTypeAllocator
-    for SharedRefAllocator<Alloc>
-{
-    unsafe fn allocate_by_info(
-        &mut self,
-        memory_requirements: vk::MemoryRequirements,
-        memory_property_flags: vk::MemoryPropertyFlags,
-        allocate_info: vk::MemoryAllocateInfo,
-    ) -> Result<Allocation> {
-        self.allocator.borrow_mut().allocate_by_info(
-            memory_requirements,
-            memory_property_flags,
-            allocate_info,
-        )
     }
 }
 

--- a/src/graphics/vulkan/device_allocator/shared_ref.rs
+++ b/src/graphics/vulkan/device_allocator/shared_ref.rs
@@ -1,4 +1,4 @@
-use super::{Allocation, DeviceAllocator};
+use super::{Allocation, DeviceAllocator, MemoryTypeAllocator};
 
 use anyhow::Result;
 use ash::vk;
@@ -50,6 +50,23 @@ impl<Alloc: DeviceAllocator> DeviceAllocator for SharedRefAllocator<Alloc> {
 
     fn managed_by_me(&self, allocation: &super::Allocation) -> bool {
         self.allocator.borrow().managed_by_me(allocation)
+    }
+}
+
+impl<Alloc: MemoryTypeAllocator + DeviceAllocator> MemoryTypeAllocator
+    for SharedRefAllocator<Alloc>
+{
+    unsafe fn allocate_by_info(
+        &mut self,
+        memory_requirements: vk::MemoryRequirements,
+        memory_property_flags: vk::MemoryPropertyFlags,
+        allocate_info: vk::MemoryAllocateInfo,
+    ) -> Result<Allocation> {
+        self.allocator.borrow_mut().allocate_by_info(
+            memory_requirements,
+            memory_property_flags,
+            allocate_info,
+        )
     }
 }
 

--- a/src/graphics/vulkan/device_allocator/shared_ref.rs
+++ b/src/graphics/vulkan/device_allocator/shared_ref.rs
@@ -1,0 +1,80 @@
+use super::{Allocation, DeviceAllocator};
+
+use anyhow::Result;
+use ash::vk;
+use std::{cell::RefCell, rc::Rc};
+
+/// A device allocator implementation which represents a shared reference to an
+/// underlying allocator implementation.
+///
+/// This is useful because multiple other allocators often compose over the
+/// passthrough. When this occurs, they often need to use the *same* instance
+/// of the passthrough allocator.
+pub struct SharedRefAllocator<Alloc: DeviceAllocator> {
+    allocator: Rc<RefCell<Alloc>>,
+}
+
+impl<Alloc: DeviceAllocator> SharedRefAllocator<Alloc> {
+    pub fn new(allocator: Alloc) -> Self {
+        Self {
+            allocator: Rc::new(RefCell::new(allocator)),
+        }
+    }
+}
+
+impl<Alloc: DeviceAllocator> Clone for SharedRefAllocator<Alloc> {
+    fn clone(&self) -> Self {
+        Self {
+            allocator: self.allocator.clone(),
+        }
+    }
+}
+
+impl<Alloc: DeviceAllocator> DeviceAllocator for SharedRefAllocator<Alloc> {
+    unsafe fn allocate(
+        &mut self,
+        memory_requirements: vk::MemoryRequirements,
+        memory_property_flags: vk::MemoryPropertyFlags,
+    ) -> Result<Allocation> {
+        self.allocator
+            .borrow_mut()
+            .allocate(memory_requirements, memory_property_flags)
+    }
+
+    unsafe fn free(
+        &mut self,
+        allocation: &super::Allocation,
+    ) -> anyhow::Result<()> {
+        self.allocator.borrow_mut().free(allocation)
+    }
+
+    fn managed_by_me(&self, allocation: &super::Allocation) -> bool {
+        self.allocator.borrow().managed_by_me(allocation)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::graphics::vulkan::device_allocator::{
+        stub_allocator::StubAllocator, SharedRefAllocator,
+    };
+
+    #[test]
+    pub fn can_clone() {
+        let allocator = SharedRefAllocator::new(StubAllocator {});
+        let _alloc2 = allocator.clone();
+    }
+
+    #[should_panic]
+    #[test]
+    pub fn the_stub_allocator_cannot_clone() {
+        let stub = StubAllocator {};
+        let _cloned = stub.clone();
+    }
+
+    impl Clone for StubAllocator {
+        fn clone(&self) -> Self {
+            panic!("The Stub Allocator does not support cloning")
+        }
+    }
+}

--- a/src/graphics/vulkan/device_allocator/size_selector.rs
+++ b/src/graphics/vulkan/device_allocator/size_selector.rs
@@ -1,0 +1,54 @@
+use super::{Allocation, DeviceAllocator, MemUnit};
+
+use anyhow::Result;
+use ash::vk;
+
+pub struct SizeSelector<
+    SmallAllocator: DeviceAllocator,
+    LargeAllocator: DeviceAllocator,
+> {
+    small_allocator: SmallAllocator,
+    large_allocator: LargeAllocator,
+    size: u64,
+}
+
+impl<SmallAllocator: DeviceAllocator, LargeAllocator: DeviceAllocator>
+    SizeSelector<SmallAllocator, LargeAllocator>
+{
+    /// Create a new allocator which defers to the small allocator for
+    /// allocations below size bytes, and otherwise uses the large allocator.
+    pub fn new(
+        small_allocator: SmallAllocator,
+        size: MemUnit,
+        large_allocator: LargeAllocator,
+    ) -> Self {
+        Self {
+            small_allocator,
+            large_allocator,
+            size: size.to_bytes(),
+        }
+    }
+}
+
+impl<SmallAllocator: DeviceAllocator, LargeAllocator: DeviceAllocator>
+    DeviceAllocator for SizeSelector<SmallAllocator, LargeAllocator>
+{
+    unsafe fn allocate(
+        &mut self,
+        allocate_info: vk::MemoryAllocateInfo,
+    ) -> Result<Allocation> {
+        if allocate_info.allocation_size < self.size {
+            self.small_allocator.allocate(allocate_info)
+        } else {
+            self.large_allocator.allocate(allocate_info)
+        }
+    }
+
+    unsafe fn free(&mut self, allocation: &Allocation) -> Result<()> {
+        if allocation.byte_size < self.size {
+            self.small_allocator.free(allocation)
+        } else {
+            self.large_allocator.free(allocation)
+        }
+    }
+}

--- a/src/graphics/vulkan/device_allocator/stub_allocator.rs
+++ b/src/graphics/vulkan/device_allocator/stub_allocator.rs
@@ -6,15 +6,14 @@ use ash::vk;
 pub struct StubAllocator {}
 
 impl DeviceAllocator for StubAllocator {
-    unsafe fn allocate(
-        &mut self,
-        _: vk::MemoryRequirements,
-        _: vk::MemoryPropertyFlags,
-    ) -> Result<Allocation> {
+    unsafe fn free(&mut self, _allocation: &Allocation) -> Result<()> {
         todo!()
     }
 
-    unsafe fn free(&mut self, _allocation: &Allocation) -> Result<()> {
+    unsafe fn allocate(
+        &mut self,
+        _allocate_info: vk::MemoryAllocateInfo,
+    ) -> Result<Allocation> {
         todo!()
     }
 }

--- a/src/graphics/vulkan/device_allocator/stub_allocator.rs
+++ b/src/graphics/vulkan/device_allocator/stub_allocator.rs
@@ -1,0 +1,24 @@
+use super::{Allocation, DeviceAllocator};
+
+use anyhow::Result;
+use ash::vk;
+
+pub struct StubAllocator {}
+
+impl DeviceAllocator for StubAllocator {
+    unsafe fn allocate(
+        &mut self,
+        _: vk::MemoryRequirements,
+        _: vk::MemoryPropertyFlags,
+    ) -> Result<Allocation> {
+        todo!()
+    }
+
+    unsafe fn free(&mut self, _allocation: &Allocation) -> Result<()> {
+        todo!()
+    }
+
+    fn managed_by_me(&self, _allocation: &Allocation) -> bool {
+        todo!()
+    }
+}

--- a/src/graphics/vulkan/device_allocator/stub_allocator.rs
+++ b/src/graphics/vulkan/device_allocator/stub_allocator.rs
@@ -17,8 +17,4 @@ impl DeviceAllocator for StubAllocator {
     unsafe fn free(&mut self, _allocation: &Allocation) -> Result<()> {
         todo!()
     }
-
-    fn managed_by_me(&self, _allocation: &Allocation) -> bool {
-        todo!()
-    }
 }

--- a/src/graphics/vulkan/device_allocator/suballocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/suballocator/mod.rs
@@ -3,13 +3,14 @@ mod suballocator;
 
 use super::{Allocation, DeviceAllocator};
 
-use self::region::{MergeResult, Region};
+use self::region::Region;
 
 use anyhow::Result;
 use ash::vk;
 
 /// A suballocator can divvy up a single allocation into multiple
 /// non-overlapping allocations.
+#[derive(Debug)]
 pub struct Suballocator {
     block: Allocation,
     free_regions: Vec<Region>,
@@ -45,7 +46,6 @@ impl DeviceAllocator for Suballocator {
         self.free_region(Region::new(
             allocation.offset - self.block.offset,
             allocation.byte_size,
-        ));
-        Ok(())
+        ))
     }
 }

--- a/src/graphics/vulkan/device_allocator/suballocator/mod.rs
+++ b/src/graphics/vulkan/device_allocator/suballocator/mod.rs
@@ -1,0 +1,80 @@
+mod region;
+
+use super::{Allocation, DeviceAllocator};
+
+use self::region::{MergeResult, Region};
+
+use anyhow::Result;
+use ash::vk;
+
+/// A pool suballocator can divvy up a single large allocation - the 'block' -
+/// into multiple suballocations which take up a subset of the block.
+pub struct Suballocator {
+    block: Allocation,
+    free_regions: Vec<Region>,
+}
+
+impl Suballocator {
+    pub fn new(allocation: Allocation) -> Self {
+        Self {
+            free_regions: vec![Region::new(
+                allocation.offset,
+                allocation.byte_size,
+            )],
+            block: allocation,
+        }
+    }
+
+    pub unsafe fn free_all(
+        &mut self,
+        allocator: &mut impl DeviceAllocator,
+    ) -> Result<()> {
+        allocator.free(&self.block)?;
+        self.block = Allocation::null();
+        Ok(())
+    }
+
+    fn find_free_region(&mut self, size: u64) -> Option<Region> {
+        for i in 0..self.free_regions.len() {
+            if size == self.free_regions[i].size {
+                return Some(self.free_regions.remove(i));
+            } else if size < self.free_regions[i].size {
+                return Some(self.free_regions[i].take_subregion(size));
+            }
+        }
+        None
+    }
+}
+
+//
+// impl DeviceAllocator for PoolSuballocator {
+//     unsafe fn allocate(
+//         &mut self,
+//         memory_allocate_info: vk::MemoryAllocateInfo,
+//     ) -> Result<Allocation> {
+//         use anyhow::Context;
+//
+//         if self.block.memory_type_index
+//             != memory_allocate_info.memory_type_index
+//         {
+//             anyhow::bail!(
+//                 "memory type is not supported for this suballocator!"
+//             );
+//         }
+//
+//         let region = self
+//             .find_free_region(memory_allocate_info.allocation_size)
+//             .with_context(|| "unable to find a free region of memory")?;
+//
+//         Ok(Allocation {
+//             memory: self.block.memory,
+//             memory_type_index: self.block.memory_type_index,
+//             offset: region.offset,
+//             byte_size: region.size,
+//         })
+//     }
+//
+//     unsafe fn free(&mut self, allocation: &Allocation) -> Result<()> {
+//         todo!()
+//     }
+// }

--- a/src/graphics/vulkan/device_allocator/suballocator/region.rs
+++ b/src/graphics/vulkan/device_allocator/suballocator/region.rs
@@ -1,4 +1,4 @@
-use std::ops::{Bound, Range, RangeBounds};
+use std::ops::{Bound, RangeBounds};
 
 use crate::graphics::vulkan::device_allocator::Allocation;
 

--- a/src/graphics/vulkan/device_allocator/suballocator/region.rs
+++ b/src/graphics/vulkan/device_allocator/suballocator/region.rs
@@ -1,0 +1,139 @@
+use crate::graphics::vulkan::device_allocator::Allocation;
+
+/// A region represents a range within an allocation.
+///
+/// Regions within an allocation never overlap.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Region {
+    pub offset: u64,
+    pub size: u64,
+}
+
+/// This enum represents the result of attempting to merge two regions.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MergeResult {
+    /// Indicates that the regions cannot be merged because they are not
+    /// contiguous.
+    NonContiguous,
+
+    /// Indicactes that the regions were merged into a new contiguous region.
+    Contiguous(Region),
+}
+
+impl Region {
+    pub fn new(offset: u64, size: u64) -> Self {
+        Self { offset, size }
+    }
+
+    /// Create a region which occupies an entire allocation.
+    pub fn new_whole_region(allocation: &Allocation) -> Self {
+        Self::new(allocation.offset, allocation.byte_size)
+    }
+
+    /// The address where this Region begins within the parent allocation.
+    pub fn start(&self) -> u64 {
+        self.offset
+    }
+
+    /// The address where this Region ends within the parent allocation.
+    pub fn end(&self) -> u64 {
+        self.offset + self.size
+    }
+
+    /// Returns true when this region and the other region are touching with
+    /// no space between.
+    pub fn is_contiguous(&self, other: &Self) -> bool {
+        self.start() == other.end() || self.end() == other.start()
+    }
+
+    /// Attempt to merge this region with another.
+    pub fn merge(&self, other: &Self) -> MergeResult {
+        if self.is_contiguous(other) {
+            // SAFE - the line above checks that the regions are contiguous
+            MergeResult::Contiguous(unsafe { self.merge_unsafe(other) })
+        } else {
+            MergeResult::NonContiguous
+        }
+    }
+
+    /// Take a subregion from this region, updating the size and offset to
+    /// match.
+    pub fn take_subregion(&mut self, size: u64) -> Region {
+        let new_region = Region::new(self.offset, size);
+        self.offset += size;
+        self.size -= size;
+        new_region
+    }
+
+    /// Merge this region with another region.
+    ///
+    /// # Unsafe Because
+    ///
+    /// - this method does not check that the regions are adjacent before
+    ///   merging
+    unsafe fn merge_unsafe(&self, other: &Self) -> Self {
+        Self {
+            offset: self.offset.min(other.offset),
+            size: self.size + other.size,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::graphics::vulkan::device_allocator::Allocation;
+
+    #[test]
+    pub fn start_end() {
+        assert_eq!(Region::new(8, 123).start(), 8);
+        assert_eq!(Region::new(8, 123).end(), 131);
+    }
+
+    #[test]
+    pub fn new_region_for_whole_allocation_test() {
+        let allocation = dummy_allocation(23, 1234);
+        let region = Region::new_whole_region(&allocation);
+        assert_eq!(region.offset, 23);
+        assert_eq!(region.size, 1234);
+    }
+
+    #[test]
+    pub fn is_contiguous_test() {
+        let a = Region::new(0, 512);
+        let b = Region::new(512, 256);
+        assert!(a.is_contiguous(&b));
+        assert!(!a.is_contiguous(&Region::new(513, 20)));
+    }
+
+    #[test]
+    pub fn merge_contiguous() {
+        let a = Region::new(0, 512);
+        let b = Region::new(512, 256);
+        assert_eq!(a.merge(&b), MergeResult::Contiguous(Region::new(0, 768)));
+        assert_eq!(b.merge(&a), MergeResult::Contiguous(Region::new(0, 768)));
+    }
+
+    #[test]
+    pub fn merge_non_contiguous() {
+        let a = Region::new(0, 256);
+        let b = Region::new(512, 256);
+        assert_eq!(a.merge(&b), MergeResult::NonContiguous);
+        assert_eq!(b.merge(&a), MergeResult::NonContiguous);
+    }
+
+    #[test]
+    pub fn take_subregion_test() {
+        let mut a = Region::new(0, 256);
+        let b = a.take_subregion(64);
+        assert_eq!(Region::new(0, 64), b);
+        assert_eq!(Region::new(64, 192), a);
+    }
+
+    fn dummy_allocation(offset: u64, size: u64) -> Allocation {
+        let mut allocation = Allocation::null();
+        allocation.offset = offset;
+        allocation.byte_size = size;
+        allocation
+    }
+}

--- a/src/graphics/vulkan/device_allocator/suballocator/suballocator.rs
+++ b/src/graphics/vulkan/device_allocator/suballocator/suballocator.rs
@@ -91,6 +91,12 @@ impl Suballocator {
 
         Ok(())
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.free_regions.len() == 1
+            && self.free_regions[0].offset == 0
+            && self.free_regions[0].size == self.block.byte_size
+    }
 }
 
 #[cfg(test)]

--- a/src/graphics/vulkan/device_allocator/suballocator/suballocator.rs
+++ b/src/graphics/vulkan/device_allocator/suballocator/suballocator.rs
@@ -1,0 +1,240 @@
+use crate::graphics::vulkan::device_allocator::{Allocation, DeviceAllocator};
+
+use super::region::{MergeResult, Region};
+
+use anyhow::Result;
+
+use super::Suballocator;
+
+impl Suballocator {
+    pub fn new(allocation: Allocation) -> Self {
+        Self {
+            free_regions: vec![Region::new(
+                allocation.offset,
+                allocation.byte_size,
+            )],
+            block: allocation,
+        }
+    }
+
+    pub unsafe fn free_block(
+        &mut self,
+        allocator: &mut impl DeviceAllocator,
+    ) -> Result<()> {
+        allocator.free(&self.block)?;
+        self.block = Allocation::null();
+        Ok(())
+    }
+
+    /// Find and take a region with the requested size from the free regions.
+    ///
+    /// If no region is large enough, or no regions are remaining, then None is
+    /// returned.
+    pub fn allocate_region(&mut self, size: u64) -> Option<Region> {
+        for i in 0..self.free_regions.len() {
+            if size == self.free_regions[i].size {
+                return Some(self.free_regions.remove(i));
+            } else if size < self.free_regions[i].size {
+                return Some(self.free_regions[i].take_subregion(size));
+            }
+        }
+        None
+    }
+
+    /// Free a subregion back into the set of free regions.
+    /// Regions are automatically joined to minimize fragmentation.
+    pub fn free_region(&mut self, region: Region) -> Result<()> {
+        let mut was_merged = false;
+        let mut i = 0;
+
+        while i < self.free_regions.len() && !was_merged {
+            if self.free_regions[i] == region
+                || self.free_regions[i].is_overlapping(&region)
+            {
+                anyhow::bail!(
+                    "Attempting to free a suballocation twice will lead to
+                     data inconsistency!"
+                );
+            } else if let MergeResult::Contiguous(merged) =
+                region.merge(&self.free_regions[i])
+            {
+                let mut to_insert = merged;
+
+                // check if the new merged region can fuse with the next free
+                // region too. If it can, then build the fully merged region
+                // and remove one entry from the free region vector.
+                if i + 1 < self.free_regions.len() {
+                    if let MergeResult::Contiguous(merged) =
+                        to_insert.merge(&self.free_regions[i + 1])
+                    {
+                        to_insert = merged;
+                        self.free_regions.remove(i + 1);
+                    }
+                }
+
+                self.free_regions[i] = to_insert;
+                was_merged = true;
+            } else {
+                if region.end() < self.free_regions[i].start() {
+                    break;
+                }
+                i += 1;
+            }
+        }
+
+        // The region is not contiguous with any other region in the
+        // free_region vector. Insert it wherever the merge loop stopped so
+        // that free_regions stay consecutive.
+        if !was_merged {
+            self.free_regions.insert(i, region);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::graphics::vulkan::device_allocator::Allocation;
+
+    #[test]
+    pub fn test_allocate_region() {
+        let allocation = fake_allocation(1024);
+        let mut suballocator = Suballocator::new(allocation);
+
+        assert_eq!(suballocator.free_regions, vec![Region::new(0, 1024)]);
+
+        let region = suballocator.allocate_region(256);
+        assert_eq!(region, Some(Region::new(0, 256)));
+        assert_eq!(suballocator.free_regions, vec![Region::new(256, 768)]);
+
+        let remaining = suballocator.allocate_region(768);
+        assert_eq!(remaining, Some(Region::new(256, 768)));
+        assert_eq!(suballocator.free_regions, vec![]);
+    }
+
+    #[test]
+    pub fn test_free_whole_region() {
+        let mut sub = Suballocator::new(fake_allocation(1024));
+
+        let region = sub.allocate_region(1024).unwrap();
+        assert_eq!(region, Region::new(0, 1024));
+        assert_eq!(sub.free_regions, vec![]);
+
+        sub.free_region(region);
+        assert_eq!(sub.free_regions, vec![Region::new(0, 1024)]);
+    }
+
+    #[test]
+    pub fn test_split_region() {
+        let mut sub = Suballocator::new(fake_allocation(1024));
+
+        let region = sub.allocate_region(512).unwrap();
+        assert_eq!(region, Region::new(0, 512));
+        assert_eq!(sub.free_regions, vec![Region::new(512, 512)]);
+
+        sub.free_region(region);
+        assert_eq!(sub.free_regions, vec![Region::new(0, 1024)]);
+    }
+
+    #[test]
+    pub fn test_merge_front_and_back() {
+        let mut sub = Suballocator::new(fake_allocation(1024));
+
+        let a = sub.allocate_region(256).unwrap();
+        let b = sub.allocate_region(512).unwrap();
+        let c = sub.allocate_region(256).unwrap();
+
+        assert_eq!(sub.free_regions, vec![]);
+
+        sub.free_region(c);
+        assert_eq!(sub.free_regions, vec![Region::new(768, 256)]);
+
+        sub.free_region(a);
+        assert_eq!(
+            sub.free_regions,
+            vec![Region::new(0, 256), Region::new(768, 256)]
+        );
+
+        sub.free_region(b);
+        assert_eq!(sub.free_regions, vec![Region::new(0, 1024)]);
+    }
+
+    #[test]
+    pub fn test_merge_front_with_leading() {
+        let mut sub = Suballocator::new(fake_allocation(1024));
+
+        let a = sub.allocate_region(256).unwrap();
+        let b = sub.allocate_region(256).unwrap();
+        let c = sub.allocate_region(256).unwrap();
+        let d = sub.allocate_region(256).unwrap();
+
+        assert_eq!(sub.free_regions, vec![]);
+
+        sub.free_region(a);
+        assert_eq!(sub.free_regions, vec![Region::new(0, 256)]);
+
+        sub.free_region(d);
+        assert_eq!(
+            sub.free_regions,
+            vec![Region::new(0, 256), Region::new(768, 256)]
+        );
+
+        sub.free_region(c);
+        assert_eq!(
+            sub.free_regions,
+            vec![Region::new(0, 256), Region::new(512, 512)]
+        );
+
+        sub.free_region(b);
+        assert_eq!(sub.free_regions, vec![Region::new(0, 1024)]);
+    }
+
+    #[test]
+    pub fn test_merge_back_with_trailing() {
+        let mut sub = Suballocator::new(fake_allocation(1024));
+
+        let a = sub.allocate_region(256).unwrap();
+        let b = sub.allocate_region(256).unwrap();
+        let c = sub.allocate_region(256).unwrap();
+        let d = sub.allocate_region(256).unwrap();
+
+        assert_eq!(sub.free_regions, vec![]);
+
+        sub.free_region(a);
+        assert_eq!(sub.free_regions, vec![Region::new(0, 256)]);
+
+        sub.free_region(d);
+        assert_eq!(
+            sub.free_regions,
+            vec![Region::new(0, 256), Region::new(768, 256)]
+        );
+
+        sub.free_region(b);
+        assert_eq!(
+            sub.free_regions,
+            vec![Region::new(0, 512), Region::new(768, 256)]
+        );
+
+        sub.free_region(c);
+        assert_eq!(sub.free_regions, vec![Region::new(0, 1024)]);
+    }
+
+    #[should_panic]
+    #[test]
+    pub fn test_double_free() {
+        let mut sub = Suballocator::new(fake_allocation(1024));
+        let a = sub.allocate_region(512).unwrap();
+        let b = sub.allocate_region(512).unwrap();
+        sub.free_region(b).unwrap();
+        sub.free_region(a).unwrap();
+        sub.free_region(a).unwrap();
+    }
+
+    fn fake_allocation(size: u64) -> Allocation {
+        let mut allocation = Allocation::null();
+        allocation.byte_size = size;
+        allocation
+    }
+}

--- a/src/graphics/vulkan/device_allocator/type_index.rs
+++ b/src/graphics/vulkan/device_allocator/type_index.rs
@@ -1,0 +1,55 @@
+use super::{Allocation, DeviceAllocator};
+
+use anyhow::Result;
+use ash::vk;
+
+/// The type index allocator creates a separate memory allocator for each memory
+/// type index, then dispatches allocations and frees.
+pub struct TypeIndexAllocator<Allocator: DeviceAllocator> {
+    allocators: Vec<Allocator>,
+}
+
+impl<Allocator: DeviceAllocator> TypeIndexAllocator<Allocator> {
+    pub fn new<Factory: FnMut(u32, vk::MemoryType) -> Allocator>(
+        ash_instance: &ash::Instance,
+        physical_device: ash::vk::PhysicalDevice,
+        mut factory: Factory,
+    ) -> Self {
+        use ash::version::InstanceV1_0;
+
+        let memory_properties = unsafe {
+            ash_instance.get_physical_device_memory_properties(physical_device)
+        };
+
+        let mut allocators = Vec::new();
+        allocators.reserve(memory_properties.memory_type_count as usize);
+
+        for i in 0..memory_properties.memory_type_count {
+            allocators
+                .push(factory(i, memory_properties.memory_types[i as usize]));
+        }
+
+        Self { allocators }
+    }
+}
+
+impl<Allocator: DeviceAllocator> DeviceAllocator
+    for TypeIndexAllocator<Allocator>
+{
+    unsafe fn allocate(
+        &mut self,
+        allocate_info: vk::MemoryAllocateInfo,
+    ) -> Result<Allocation> {
+        self.allocators[allocate_info.memory_type_index as usize]
+            .allocate(allocate_info)
+    }
+
+    unsafe fn free(&mut self, allocation: &Allocation) -> Result<()> {
+        if allocation.is_null() {
+            Ok(())
+        } else {
+            self.allocators[allocation.memory_type_index as usize]
+                .free(allocation)
+        }
+    }
+}

--- a/src/graphics/vulkan/mod.rs
+++ b/src/graphics/vulkan/mod.rs
@@ -10,6 +10,7 @@ pub mod shader_module;
 pub mod swapchain;
 pub mod texture;
 pub mod window_surface;
+pub mod device_allocator;
 
 pub use self::{
     device::Device, instance::Instance, swapchain::Swapchain,

--- a/src/graphics/vulkan/texture/mod.rs
+++ b/src/graphics/vulkan/texture/mod.rs
@@ -6,6 +6,8 @@ use crate::graphics::vulkan::Device;
 use ash::vk;
 use std::sync::Arc;
 
+use super::device_allocator::Allocation;
+
 /// The TextureImage maintains the image, view, and memory, which are required
 /// when rendering with a texture.
 pub struct TextureImage {
@@ -13,7 +15,9 @@ pub struct TextureImage {
     image: vk::Image,
     extent: vk::Extent3D,
     view: vk::ImageView,
-    memory: vk::DeviceMemory,
+
+    allocation: Allocation,
+
     device: Arc<Device>,
 }
 

--- a/src/graphics/vulkan/texture/texture_image.rs
+++ b/src/graphics/vulkan/texture/texture_image.rs
@@ -147,7 +147,7 @@ impl TextureImage {
         }
 
         let mut mip_level = 0;
-        let mut offset: u64 = 0;
+        let mut offset: u64 = src.allocation().offset;
         for extent in mipmap_sizes {
             self.write_barrier(command_buffer, mip_level);
             self.copy_buffer_to_image(

--- a/src/graphics/vulkan/texture/texture_image.rs
+++ b/src/graphics/vulkan/texture/texture_image.rs
@@ -94,9 +94,9 @@ impl TextureImage {
 
     /// Upload a texture's data from a buffer.
     ///
-    /// This method is just an alias to [upload_mipmaps_from_buffer] which only
-    /// updates the first mipmap. It's particularly convenient for textures
-    /// which only have a single mipmap level.
+    /// This method is just an alias to [Self::upload_mipmaps_from_buffer]
+    /// which only updates the first mipmap. It's particularly convenient for
+    /// textures which only have a single mipmap level.
     pub unsafe fn upload_from_buffer<Buf>(
         &mut self,
         command_buffer: vk::CommandBuffer,
@@ -114,9 +114,9 @@ impl TextureImage {
 
     /// Upload a texture's mipmaps from a buffer.
     ///
-    /// * This method assumes that each mipmap has the same [bytes_per_pixel]
+    /// * This method assumes that each mipmap has the same `bytes_per_pixel`
     ///   as the texture image.
-    /// * Order is super important. The first entry in [mipmap_sizes]
+    /// * Order is super important. The first entry in `mipmap_sizes`
     ///   corresponds to the first region of memory in the src bufer. The
     ///   mipmap extents are used to compute the byte offset and size of each
     ///   mipmap region.
@@ -147,7 +147,7 @@ impl TextureImage {
         }
 
         let mut mip_level = 0;
-        let mut offset: u64 = src.allocation().offset;
+        let mut offset: u64 = 0;
         for extent in mipmap_sizes {
             self.write_barrier(command_buffer, mip_level);
             self.copy_buffer_to_image(

--- a/src/graphics/vulkan/texture/texture_image.rs
+++ b/src/graphics/vulkan/texture/texture_image.rs
@@ -52,7 +52,7 @@ impl TextureImage {
             device.logical_device.bind_image_memory(
                 image,
                 allocation.memory,
-                0,
+                allocation.offset,
             )?;
         }
 


### PR DESCRIPTION
# Background

The application currently directly allocates each piece of required memory. This is super non-optimal because Vulkan implementations have a fixed upper limit on the number of concurrent allocations. Moreover, many of the allocations were small and short lived.

The purpose of this change is to introduce a `DeviceAllocator` trait and implementation(s) which enable pooling of GPU memory resources without the rest of the app needing to worry about the details.

# What Has Changed

- create the `DeviceAllocator` trait
- create implementations for the trait
  - passthrough, an implementation which directly allocates memory
  - suballocator, an implementation which directly allocates subregions of a large piece of memory
  - pool_allocator, an implementation which defers to suballocators, acquiring new and releasing them on demand
  - size_selector, a decorator which picks one of two allocators based on the requested memory size
  - metrics_allocator, a decorator which tracks allocations and generates a report